### PR TITLE
Hc/rum 604/addressing code smells

### DIFF
--- a/sdk/src/CrashReporter.ts
+++ b/sdk/src/CrashReporter.ts
@@ -37,8 +37,8 @@ export default class CrashReporter {
    * Javascript side should be responsible for caching Crash Reports.
    *
    * @param apiKey - Access key for Raygun API
-   * @param user
-   * @param tags
+   * @param user - A User object that represents the current user.
+   * @param tags - A set of strings, where each string is a tag.
    * @param disableNativeCrashReporting - Whether or not to enable Native side error reporting
    * @param customCrashReportingEndpoint - Custom endpoint for crash reports (may be empty or null)
    * @param onBeforeSendingCrashReport - A lambda to execute before each Crash Report transmission

--- a/sdk/src/CrashReporter.ts
+++ b/sdk/src/CrashReporter.ts
@@ -77,11 +77,7 @@ export default class CrashReporter {
       onUnhandled: this.processUnhandledRejection
     });
 
-    //If NATIVE crash reporting is enabled then the native side will handle caching
-    //Otherwise the react native side will need to apply caching logic/
-    if (disableNativeCrashReporting) {
-      setTimeout(() => this.sendCachedReports(apiKey, customCrashReportingEndpoint), 10);
-    }
+    this.sendCachedReports(apiKey, customCrashReportingEndpoint).then();
   }
 
   //#endregion--------------------------------------------------------------------------------------

--- a/sdk/src/CrashReporter.ts
+++ b/sdk/src/CrashReporter.ts
@@ -1,12 +1,5 @@
 import { cleanFilePath, clone, error, filterOutReactFrames, log, noAddressAt, upperFirst, warn } from './Utils';
-import {
-  BeforeSendHandler,
-  Breadcrumb,
-  BreadcrumbOption,
-  CrashReportPayload,
-  CustomData,
-  User
-} from './Types';
+import { BeforeSendHandler, Breadcrumb, BreadcrumbOption, CrashReportPayload, CustomData, User } from './Types';
 import { StackFrame } from 'react-native/Libraries/Core/Devtools/parseErrorStack';
 import { NativeModules, Platform } from 'react-native';
 
@@ -172,10 +165,11 @@ export default class CrashReporter {
    * @param error - The caught error
    * @param isFatal - Whether or not the error was fatal
    */
-  async processUnhandledError(error: Error, isFatal?: boolean) { if (!error || !error.stack) {
-    warn('Unrecognized error occurred');
-    return;
-  }
+  async processUnhandledError(error: Error, isFatal?: boolean) {
+    if (!error || !error.stack) {
+      warn('Unrecognized error occurred');
+      return;
+    }
 
     //Extract the errors stack trace
     const parseErrorStack = require('react-native/Libraries/Core/Devtools/parseErrorStack');
@@ -185,7 +179,7 @@ export default class CrashReporter {
     const symbolicateStackTrace = require('react-native/Libraries/Core/Devtools/symbolicateStackTrace');
     const cleanedStackFrames: StackFrame[] = __DEV__
       ? await symbolicateStackTrace(stackFrames)
-      : {stack: cleanFilePath(stackFrames)};
+      : { stack: cleanFilePath(stackFrames) };
 
     const stack = cleanedStackFrames || [].filter(filterOutReactFrames).map(noAddressAt);
 
@@ -195,9 +189,10 @@ export default class CrashReporter {
 
     const payload = await this.generateCrashReportPayload(error, stack);
 
-    const modifiedPayload = (this.onBeforeSendingCrashReport && typeof this.onBeforeSendingCrashReport === 'function')
-      ? this.onBeforeSendingCrashReport(Object.freeze(payload))
-      : payload;
+    const modifiedPayload =
+      this.onBeforeSendingCrashReport && typeof this.onBeforeSendingCrashReport === 'function'
+        ? this.onBeforeSendingCrashReport(Object.freeze(payload))
+        : payload;
 
     if (!modifiedPayload) {
       return;
@@ -211,7 +206,6 @@ export default class CrashReporter {
 
     log('Send crash report via JS');
     this.sendCrashReport(modifiedPayload, this.apiKey, this.customCrashReportingEndpoint);
-
   }
 
   /**
@@ -287,7 +281,12 @@ export default class CrashReporter {
    * @param customEndpoint
    * @param isAlreadyCached
    */
-  async sendCrashReport(report: CrashReportPayload, apiKey: string, customEndpoint?: string, isAlreadyCached?: boolean) {
+  async sendCrashReport(
+    report: CrashReportPayload,
+    apiKey: string,
+    customEndpoint?: string,
+    isAlreadyCached?: boolean
+  ) {
     return fetch(customEndpoint || this.RAYGUN_CRASH_REPORT_ENDPOINT + '?apiKey=' + encodeURIComponent(apiKey), {
       method: 'POST',
       mode: 'cors',

--- a/sdk/src/CrashReporter.ts
+++ b/sdk/src/CrashReporter.ts
@@ -189,8 +189,6 @@ export default class CrashReporter {
 
     const stack = cleanedStackFrames || [].filter(filterOutReactFrames).map(noAddressAt);
 
-    log("HERE");
-
     if (isFatal) {
       this.tags.add('Fatal');
     }

--- a/sdk/src/CrashReporter.ts
+++ b/sdk/src/CrashReporter.ts
@@ -1,5 +1,13 @@
 import { cleanFilePath, clone, error, filterOutReactFrames, log, noAddressAt, upperFirst, warn } from './Utils';
-import { BeforeSendHandler, Breadcrumb, BreadcrumbOption, CrashReportPayload, CustomData, Session } from './Types';
+import {
+  BeforeSendHandler,
+  Breadcrumb,
+  BreadcrumbOption,
+  CrashReportPayload,
+  CustomData,
+  Session,
+  User
+} from './Types';
 import { StackFrame } from 'react-native/Libraries/Core/Devtools/parseErrorStack';
 import { NativeModules, Platform } from 'react-native';
 
@@ -14,7 +22,8 @@ const { version: clientVersion } = require('../package.json');
 export default class CrashReporter {
   //#region ----INITIALIZATION----------------------------------------------------------------------
 
-  private curSession: Session;
+  private user: User;
+  private tags: Set<string>;
   private breadcrumbs: Breadcrumb[] = [];
   private customData: CustomData = {};
   private apiKey: string;
@@ -28,24 +37,27 @@ export default class CrashReporter {
    * Initialise Javascript side error/promise rejection handlers and identify whether the Native or
    * Javascript side should be responsible for caching Crash Reports.
    *
-   * @param curSession - User session data
    * @param apiKey - Access key for Raygun API
+   * @param user
+   * @param tags
    * @param disableNativeCrashReporting - Whether or not to enable Native side error reporting
    * @param customCrashReportingEndpoint - Custom endpoint for crash reports (may be empty or null)
    * @param onBeforeSendingCrashReport - A lambda to execute before each Crash Report transmission
    * @param version - The current version of the RaygunClient
    */
   constructor(
-    curSession: Session,
     apiKey: string,
+    user: User,
+    tags: Set<string>,
     disableNativeCrashReporting: boolean,
     customCrashReportingEndpoint: string,
     onBeforeSendingCrashReport: BeforeSendHandler | null,
     version: string
   ) {
     // Assign the values parsed in (assuming initiation is the only time these are altered).
-    this.curSession = curSession;
     this.apiKey = apiKey;
+    this.user = user;
+    this.tags = tags;
     this.disableNativeCrashReporting = disableNativeCrashReporting;
     this.customCrashReportingEndpoint = customCrashReportingEndpoint;
     this.onBeforeSendingCrashReport = onBeforeSendingCrashReport;
@@ -185,7 +197,7 @@ export default class CrashReporter {
 
     //Add specific tag if this error is fatal
     if (isFatal) {
-      this.curSession.tags.add('Fatal');
+      this.tags.add('UnhandledError');
     }
 
     //Create the Crash Reporting payload structure to be send
@@ -230,7 +242,6 @@ export default class CrashReporter {
    * @param stackTrace - The errors stacktrace
    */
   async generateCrashReportPayload(error: Error, stackTrace: StackFrame[]): Promise<CrashReportPayload> {
-    const { tags, user } = this.curSession;
     const environmentDetails =
       (RaygunNativeBridge.getEnvironmentInfo && (await RaygunNativeBridge.getEnvironmentInfo())) || {};
 
@@ -263,8 +274,8 @@ export default class CrashReporter {
           Version: clientVersion
         },
         UserCustomData: this.customData,
-        Tags: [...tags],
-        User: upperFirst(user),
+        Tags: [...this.tags],
+        User: upperFirst(this.user),
         Breadcrumbs: upperFirst(this.breadcrumbs),
         Version: this.version || 'Not supplied'
       }
@@ -284,9 +295,9 @@ export default class CrashReporter {
    * @param report
    * @param apiKey
    * @param customEndpoint
-   * @param isRetry
+   * @param isAlreadyCached
    */
-  async sendCrashReport(report: CrashReportPayload, apiKey: string, customEndpoint?: string, isRetry?: boolean) {
+  async sendCrashReport(report: CrashReportPayload, apiKey: string, customEndpoint?: string, isAlreadyCached?: boolean) {
     return fetch(customEndpoint || this.RAYGUN_CRASH_REPORT_ENDPOINT + '?apiKey=' + encodeURIComponent(apiKey), {
       method: 'POST',
       mode: 'cors',
@@ -296,10 +307,10 @@ export default class CrashReporter {
       body: JSON.stringify(report)
     }).catch(err => {
       error(err);
-      log('Cache report when it failed to send', isRetry);
+      log('Cache report when it failed to send', isAlreadyCached);
 
       //If the Crash Report fails to send then cache it.
-      if (isRetry) {
+      if (isAlreadyCached) {
         log('Skip cache saved reports');
         return;
       }

--- a/sdk/src/RaygunClient.ts
+++ b/sdk/src/RaygunClient.ts
@@ -3,19 +3,13 @@
  * Crash Reporting functionality as well as managing Session specific data.
  */
 
-import {
-  BreadcrumbOption,
-  CustomData,
-  RaygunClientOptions,
-  User,
-  RealUserMonitoringTimings
-} from './Types';
-import {clone, getDeviceBasedId, log, warn} from './Utils';
+import { BreadcrumbOption, CustomData, RaygunClientOptions, User, RealUserMonitoringTimings } from './Types';
+import { clone, getDeviceBasedId, log, warn } from './Utils';
 import CrashReporter from './CrashReporter';
 import RealUserMonitor from './RealUserMonitor';
-import {NativeModules} from 'react-native';
+import { NativeModules } from 'react-native';
 
-const {RaygunNativeBridge} = NativeModules;
+const { RaygunNativeBridge } = NativeModules;
 
 /**
  * The RaygunClient is the interface in which this provider publicly shows. The bottom of this page
@@ -25,7 +19,6 @@ const {RaygunNativeBridge} = NativeModules;
  */
 
 //#region ----INITIALIZATION------------------------------------------------------------------------
-
 
 let crashReporter: CrashReporter;
 let realUserMonitor: RealUserMonitor;
@@ -46,7 +39,6 @@ let currentUser: User = {
  * @param raygunClientOptions
  */
 const init = async (raygunClientOptions: RaygunClientOptions) => {
-
   //Do not reinitialize
   if (initialized) {
     log('Already initialized');
@@ -139,11 +131,11 @@ const addTag = (...tags: string[]) => {
 const setUser = (user: User | string) => {
   //Discern the type of the user argument and apply it to the user field
   const userObj = Object.assign(
-    {firstName: '', fullName: '', email: '', isAnonymous: true},
+    { firstName: '', fullName: '', email: '', isAnonymous: true },
     typeof user === 'string'
       ? !!user
-      ? {identifier: user, isAnonymous: true}
-      : {identifier: `anonymous-${getDeviceBasedId()}`, isAnonymous: true}
+        ? { identifier: user, isAnonymous: true }
+        : { identifier: `anonymous-${getDeviceBasedId()}`, isAnonymous: true }
       : user
   );
   currentUser = userObj;

--- a/sdk/src/RaygunClient.ts
+++ b/sdk/src/RaygunClient.ts
@@ -25,7 +25,7 @@ let realUserMonitor: RealUserMonitor;
 let options: RaygunClientOptions;
 // Raygun Client Global Variables
 let initialized: boolean = false;
-let currentTags: Set<string> = new Set(['React Native']);
+let currentTags: Set<string> = new Set([]);
 let currentUser: User = {
   identifier: `anonymous-${getDeviceBasedId()}`,
   isAnonymous: true
@@ -148,7 +148,7 @@ const setUser = (user: User | string) => {
  * Clear all session data and reset the Crash Reporter and Real User Monitor.
  */
 const clearSession = () => {
-  currentTags = new Set(['React Native']);
+  currentTags = new Set([]);
   currentUser = {
     identifier: `anonymous-${getDeviceBasedId()}`,
     isAnonymous: true

--- a/sdk/src/RealUserMonitor.ts
+++ b/sdk/src/RealUserMonitor.ts
@@ -37,8 +37,8 @@ export default class RealUserMonitor {
   /**
    * RealUserMonitor: Manages RUM specific logic tasks.
    * @param apiKey - The User's API key that gives them access to RUM. (User provided)
-   * @param user
-   * @param tags
+   * @param user - A User object that represents the current user.
+   * @param tags - A set of strings, where each string is a tag.
    * @param disableNetworkMonitoring - If true, XHRInterceptor is not switched on. All requests go through without monitoring.
    * @param ignoredURLs - A string array of URLs to ignore when watching the network.
    * @param customRealUserMonitoringEndpoint - The custom API URL endpoint where this API should send data to.

--- a/sdk/src/RealUserMonitor.ts
+++ b/sdk/src/RealUserMonitor.ts
@@ -4,7 +4,7 @@ import {
   Session,
   RealUserMonitorPayload,
   NetworkTimingCallback,
-  RequestMeta
+  RequestMeta, User
 } from './Types';
 import { getDeviceBasedId, log, warn, removeProtocol, shouldIgnore } from './Utils';
 // @ts-ignore
@@ -22,8 +22,9 @@ const SessionRotateThreshold = 30 * 60 * 1000; //milliseconds (equivalent to 30 
  */
 export default class RealUserMonitor {
   //#region ----INITIALIZATION----------------------------------------------------------------------
-  private readonly currentSession: Session;
 
+  private user: User;
+  private tags: Set<string>;
   private readonly apiKey: string;
   private readonly version: string;
   private readonly disableNetworkMonitoring: boolean;
@@ -37,16 +38,18 @@ export default class RealUserMonitor {
 
   /**
    * RealUserMonitor: Manages RUM specific logic tasks.
-   * @param currentSession - The session shared between the CrashReporter and RaygunClient.
    * @param apiKey - The User's API key that gives them access to RUM. (User provided)
+   * @param user
+   * @param tags
    * @param disableNetworkMonitoring - If true, XHRInterceptor is not switched on. All requests go through without monitoring.
    * @param ignoredURLs - A string array of URLs to ignore when watching the network.
    * @param customRealUserMonitoringEndpoint - The custom API URL endpoint where this API should send data to.
    * @param version - The Version number of this application. (User provided)
    */
   constructor(
-    currentSession: Session,
     apiKey: string,
+    user: User,
+    tags: Set<string>,
     disableNetworkMonitoring = true,
     ignoredURLs: string[],
     customRealUserMonitoringEndpoint: string,
@@ -54,9 +57,10 @@ export default class RealUserMonitor {
   ) {
     // Assign the values parsed in (assuming initiation is the only time these are altered).
     this.apiKey = apiKey;
+    this.user = user;
+    this.tags = tags;
     this.disableNetworkMonitoring = disableNetworkMonitoring;
     this.customRealUserMonitoringEndpoint = customRealUserMonitoringEndpoint;
-    this.currentSession = currentSession;
     this.version = version;
     this.ignoredURLs = ignoredURLs.concat(defaultURLIgnoreList, customRealUserMonitoringEndpoint || []);
 
@@ -180,7 +184,7 @@ export default class RealUserMonitor {
     return {
       type: eventName,
       timestamp: timestamp.toISOString(),
-      user: this.currentSession.user,
+      user: this.user,
       sessionId: this.curRUMSessionId,
       version: this.version,
       os: Platform.OS,

--- a/sdk/src/RealUserMonitor.ts
+++ b/sdk/src/RealUserMonitor.ts
@@ -1,9 +1,7 @@
 import {
   RealUserMonitoringEvents,
   RealUserMonitoringTimings,
-  Session,
   RealUserMonitorPayload,
-  NetworkTimingCallback,
   RequestMeta, User
 } from './Types';
 import { getDeviceBasedId, log, warn, removeProtocol, shouldIgnore } from './Utils';

--- a/sdk/src/RealUserMonitor.ts
+++ b/sdk/src/RealUserMonitor.ts
@@ -2,7 +2,8 @@ import {
   RealUserMonitoringEvents,
   RealUserMonitoringTimings,
   RealUserMonitorPayload,
-  RequestMeta, User
+  RequestMeta,
+  User
 } from './Types';
 import { getDeviceBasedId, log, warn, removeProtocol, shouldIgnore } from './Utils';
 // @ts-ignore

--- a/sdk/src/Types.ts
+++ b/sdk/src/Types.ts
@@ -2,28 +2,8 @@ import { ErrorUtils } from 'react-native';
 
 //#region ----RAYGUN CLIENT SESSION TYPES-----------------------------------------------------------
 
-type BasicType = string | number | boolean;
-
-export type CustomData = {
-  [key: string]: BasicType | CustomData | BasicType[] | CustomData[];
-};
-
-export type Session = {
-  tags: Set<string>;
-  user: User;
-};
-
-export type User = {
-  identifier: string;
-  isAnonymous?: boolean;
-  email?: string;
-  firstName?: string;
-  fullName?: string;
-  uuid?: string;
-};
-
 export type RaygunClientOptions = {
-  apiKey: string;
+  apiKey?: string;
   version?: string;
   enableCrashReporting?: boolean;
   disableNativeCrashReporting?: boolean;
@@ -33,6 +13,21 @@ export type RaygunClientOptions = {
   customRealUserMonitoringEndpoint?: string;
   onBeforeSendingCrashReport?: BeforeSendHandler;
   ignoredURLs?: string[];
+};
+
+type BasicType = string | number | boolean;
+
+export type CustomData = {
+  [key: string]: BasicType | CustomData | BasicType[] | CustomData[];
+};
+
+export type User = {
+  identifier: string;
+  isAnonymous?: boolean;
+  email?: string;
+  firstName?: string;
+  fullName?: string;
+  uuid?: string;
 };
 
 //#endregion----------------------------------------------------------------------------------------

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,23 +1,23 @@
 import {
   init,
+  addTag,
   setUser,
+  clearSession,
   recordBreadcrumb,
   addCustomData,
-  addTag,
+  sendError,
   updateCustomData,
-  clearSession,
-  sendRUMTimingEvent,
-  sendError
+  sendRUMTimingEvent
 } from './RaygunClient';
 
 export default {
   init,
+  addTag,
   setUser,
+  clearSession,
   recordBreadcrumb,
   addCustomData,
-  addTag,
+  sendError,
   updateCustomData,
-  clearSession,
-  sendRUMTimingEvent,
-  sendError
+  sendRUMTimingEvent
 };


### PR DESCRIPTION
This branch removes certain obvious code smells (things that are over the top or unnecessary. Some of those being:

- The Session type was removed to ensure no confusion about how the SDK runs. Although it maintains user and tag information, it does not actually maintain the "session".

- User and Tags (currentUser + currentTags) are extracted from the old "sessions", these variables are still initialized on construction of the client, however they are no longer inside a method that needs to be called before the variable declaration.

- Instances of "StackTrace" have been replaces with "StackFrames". Although a stack trace is an accurate description of the objects purpose, it is misleading in the means it's treated. An array of StackFrames is technically what a StackTrace is, however, the manipulation of this list renders the meaning incoherent with it's purpose. The StackFrames are labeled as such to ensure reading the code is more intuitive. 

- Reorganizes the index / export order of methods to align with their placement within RaygunClient.ts