### PR TITLE
Updates demo raygun4reactnative dependency to utilize online version

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "raygun4reactnative": "file:raygun4reactnative-0.0.2-alpha.tgz",
+    "raygun4reactnative": "0.0.2-alpha",
     "react": "16.13.1",
     "react-native": "0.63.0"
   },


### PR DESCRIPTION
This is a small branch, it updates the demo dependency to use the online version. This is needed to release the alpha 0.0.2 version on git.