### PR TITLE
Hc/rum 644/clean up miscellaneous tasks

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -117,10 +117,16 @@ const App = () => {
 
                   // You caught some error, and now you can send it away
                   const customData: CustomData = {"Who's to blame: ": user}
-                  const tags: string[] = ["Error", "Caught", "Test"]
 
                   // Send the error away with custom data
-                  RaygunClient.sendError(new Error("Test Error: Custom Error"), customData, tags);
+                  RaygunClient.sendError(new Error("Test Error: Custom Error"),  customData, "Error", "Caught", "Test");
+
+                  // Here are three other means of sending an error, the custom data and tags placed in this method are local
+                  // to the error. If you want to use the custom data and tags for other errors and rum events,
+                  // set them using the RaygunClient.setCustomData or RaygunClient.setTags methods
+                  // RaygunClient.sendError(new Error("Test Error: Custom Error"));
+                  // RaygunClient.sendError(new Error("Test Error: Custom Error (Custom Data)"),  customData);
+                  // RaygunClient.sendError(new Error("Test Error: Custom Error (Tags)"), "Error", "Caught", "Test");
                 }}
                 title="Trigger Customize Error"
               />
@@ -151,7 +157,7 @@ const App = () => {
                 color="green"
                 testID="addTagsBtn"
                 accessibilityLabel="addTagsBtn"
-                onPress={() => RaygunClient.setTags(["Testing_1", "Testing_2", "Testing_3"])}
+                onPress={() => RaygunClient.setTags("Testing_1", "Testing_2", "Testing_3")}
                 title="Set Testing Tags"
               />
             </View>

--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -22,7 +22,7 @@ import {
 import {Colors, Header} from 'react-native/Libraries/NewAppScreen';
 import RaygunClient, {
   Breadcrumb,
-  CustomData,
+  CustomData, ManualCrashReportDetails,
   RaygunClientOptions,
   RealUserMonitoringTimings,
   User
@@ -112,21 +112,14 @@ const App = () => {
                 testID="triggerCustomErrorBtn"
                 accessibilityLabel="triggerCustomErrorBtn"
                 onPress={() => {
-                  // Current user of the application
-                  const user = "Guest"
-
                   // You caught some error, and now you can send it away
-                  const customData: CustomData = {"Who's to blame: ": user}
+                  const customData: CustomData = {"Key": "Value"};
+                  const tags: string[] = ["Error", "Caught", "Test"];
+
+                  const details: ManualCrashReportDetails = {customData, tags};
 
                   // Send the error away with custom data
-                  RaygunClient.sendError(new Error("Test Error: Custom Error"),  customData, "Error", "Caught", "Test");
-
-                  // Here are three other means of sending an error, the custom data and tags placed in this method are local
-                  // to the error. If you want to use the custom data and tags for other errors and rum events,
-                  // set them using the RaygunClient.setCustomData or RaygunClient.setTags methods
-                  // RaygunClient.sendError(new Error("Test Error: Custom Error"));
-                  // RaygunClient.sendError(new Error("Test Error: Custom Error (Custom Data)"),  customData);
-                  // RaygunClient.sendError(new Error("Test Error: Custom Error (Tags)"), "Error", "Caught", "Test");
+                  RaygunClient.sendError(new Error("Test Error: Custom Error"), details);
                 }}
                 title="Trigger Customize Error"
               />

--- a/sdk/src/CrashReporter.ts
+++ b/sdk/src/CrashReporter.ts
@@ -234,15 +234,13 @@ export default class CrashReporter {
 
     const payloadWithLocalParams: CrashReportPayload = {...payload};
 
-    if (typeof params[0] === "string"){
-      payloadWithLocalParams.Details.Tags = params;
-    }
-
     const [customData, tags] = typeof params[0] === "string" ? [null, params] : [params[0], params.slice(1)];
 
-    log("CUSTOM DATA", customData);
-    log("TAGS", tags)
-    // this.managePayload(payloadWithLocalParams);
+
+    payloadWithLocalParams.Details.UserCustomData = customData;
+    payloadWithLocalParams.Details.Tags = tags;
+
+    this.managePayload(payloadWithLocalParams);
   }
 
   /**

--- a/sdk/src/CrashReporter.ts
+++ b/sdk/src/CrashReporter.ts
@@ -10,7 +10,13 @@ import {
   upperFirst,
   warn
 } from './Utils';
-import {BeforeSendHandler, Breadcrumb, CrashReportPayload, CustomData} from './Types';
+import {
+  BeforeSendHandler,
+  Breadcrumb,
+  CrashReportPayload,
+  CustomData,
+  ManualCrashReportDetails
+} from './Types';
 import {StackFrame} from 'react-native/Libraries/Core/Devtools/parseErrorStack';
 import {NativeModules, Platform} from 'react-native';
 
@@ -222,9 +228,9 @@ export default class CrashReporter {
   /**
    * Processes a manually sent error (using local tags, not global).
    * @param error - The Error to be processed.
-   * @param params
+   * @param details
    */
-  async processManualCrashReport(error: Error, params: any[]) {
+  async processManualCrashReport(error: Error, details?: ManualCrashReportDetails) {
     if (!error || !error.stack) {
       warn('Unrecognized error occurred');
       return;
@@ -236,11 +242,14 @@ export default class CrashReporter {
 
     const payloadWithLocalParams: CrashReportPayload = {...payload};
 
-    const [customData, tags] = typeof params[0] === "string" ? [null, params] : [params[0], params.slice(1)];
-
-
-    payloadWithLocalParams.Details.UserCustomData = Object.assign(this.customData ? this.customData : {}, customData);
-    payloadWithLocalParams.Details.Tags = getCurrentTags().concat(tags);
+    if(details){
+      if(details.customData){
+        payloadWithLocalParams.Details.UserCustomData = Object.assign(this.customData ? this.customData : {}, details.customData);
+      }
+      if(details.tags){
+        payloadWithLocalParams.Details.Tags = getCurrentTags().concat(details.tags);
+      }
+    }
 
     this.managePayload(payloadWithLocalParams);
   }

--- a/sdk/src/CrashReporter.ts
+++ b/sdk/src/CrashReporter.ts
@@ -35,7 +35,7 @@ export default class CrashReporter {
   private version: string;
   private disableNativeCrashReporting: boolean;
   private onBeforeSendingCrashReport: BeforeSendHandler | null;
-  private RAYGUN_CRASH_REPORT_ENDPOINT = 'https://api.raygun.com/entries';
+  private raygunCrashReportEndpoint = 'https://api.raygun.com/entries';
 
   /**
    * Initialise Javascript side error/promise rejection handlers and identify whether the Native or
@@ -63,7 +63,7 @@ export default class CrashReporter {
     this.version = version;
 
     if (customCrashReportingEndpoint && customCrashReportingEndpoint.length > 0) {
-      this.RAYGUN_CRASH_REPORT_ENDPOINT = customCrashReportingEndpoint;
+      this.raygunCrashReportEndpoint = customCrashReportingEndpoint;
     }
 
     //Set up error handler to divert errors to crash reporter
@@ -356,7 +356,7 @@ export default class CrashReporter {
    */
   async sendCrashReport(report: CrashReportPayload) {
     //Send the message
-    return fetch( this.RAYGUN_CRASH_REPORT_ENDPOINT + '?apiKey=' + encodeURIComponent(this.apiKey), {
+    return fetch( this.raygunCrashReportEndpoint + '?apiKey=' + encodeURIComponent(this.apiKey), {
       method: 'POST',
       mode: 'cors',
       headers: {
@@ -366,7 +366,7 @@ export default class CrashReporter {
     })
     .then(() => {
       //If the message is successfully sent then attempt to transmit the cache if it isn't empty
-      this.resendCachedReports(this.apiKey, this.RAYGUN_CRASH_REPORT_ENDPOINT).then(r => {
+      this.resendCachedReports(this.apiKey, this.raygunCrashReportEndpoint).then(r => {
         log('Cache flushed');
       });
     })

--- a/sdk/src/CrashReporter.ts
+++ b/sdk/src/CrashReporter.ts
@@ -220,15 +220,13 @@ export default class CrashReporter {
   /**
    * Processes a manually sent error (using local tags, not global).
    * @param error - The Error to be processed.
-   * @param params - The parameters local to this error (sent in).
+   * @param params
    */
-  async processManualCrashReport(error: Error, ...params: any) {
+  async processManualCrashReport(error: Error, params: any[]) {
     if (!error || !error.stack) {
       warn('Unrecognized error occurred');
       return;
     }
-
-    const [customData, tags] = params.length == 1 && Array.isArray(params[0]) ? [null, params[0]] : params;
 
     const stack = await this.cleanStackTrace(error);
 
@@ -236,10 +234,15 @@ export default class CrashReporter {
 
     const payloadWithLocalParams: CrashReportPayload = {...payload};
 
-    payloadWithLocalParams.Details.UserCustomData = customData;
-    payloadWithLocalParams.Details.Tags = tags;
+    if (typeof params[0] === "string"){
+      payloadWithLocalParams.Details.Tags = params;
+    }
 
-    this.managePayload(payloadWithLocalParams);
+    const [customData, tags] = typeof params[0] === "string" ? [null, params] : [params[0], params.slice(1)];
+
+    log("CUSTOM DATA", customData);
+    log("TAGS", tags)
+    // this.managePayload(payloadWithLocalParams);
   }
 
   /**

--- a/sdk/src/CrashReporter.ts
+++ b/sdk/src/CrashReporter.ts
@@ -208,13 +208,13 @@ export default class CrashReporter {
       return;
     }
 
-    if (isFatal) {
-      setCurrentTags(getCurrentTags().concat('UnhandledError'))
-    }
-
     const stack = await this.cleanStackTrace(error);
 
     const payload = await this.generateCrashReportPayload(error, stack);
+
+    if (isFatal) {
+      payload.Details.Tags = getCurrentTags().concat("UnhandledError");
+    }
 
     this.managePayload(payload);
   }

--- a/sdk/src/CrashReporter.ts
+++ b/sdk/src/CrashReporter.ts
@@ -239,8 +239,8 @@ export default class CrashReporter {
     const [customData, tags] = typeof params[0] === "string" ? [null, params] : [params[0], params.slice(1)];
 
 
-    payloadWithLocalParams.Details.UserCustomData = customData;
-    payloadWithLocalParams.Details.Tags = tags;
+    payloadWithLocalParams.Details.UserCustomData = Object.assign(this.customData ? this.customData : {}, customData);
+    payloadWithLocalParams.Details.Tags = getCurrentTags().concat(tags);
 
     this.managePayload(payloadWithLocalParams);
   }

--- a/sdk/src/CrashReporter.ts
+++ b/sdk/src/CrashReporter.ts
@@ -245,7 +245,7 @@ export default class CrashReporter {
 
     if(details){
       if(details.customData){
-        payloadWithLocalParams.Details.UserCustomData = Object.assign(this.customData ? this.customData : {}, details.customData);
+        payloadWithLocalParams.Details.UserCustomData = Object.assign({...this.customData}, details.customData);
       }
       if(details.tags){
         payloadWithLocalParams.Details.Tags = getCurrentTags().concat(details.tags);

--- a/sdk/src/CrashReporter.ts
+++ b/sdk/src/CrashReporter.ts
@@ -217,9 +217,10 @@ export default class CrashReporter {
     const stack = await this.cleanStackTrace(error);
 
     const payload = await this.generateCrashReportPayload(error, stack);
+    payload.Details.Tags = getCurrentTags().concat("UnhandledError");
 
     if (isFatal) {
-      payload.Details.Tags = getCurrentTags().concat("UnhandledError");
+      payload.Details.Tags = getCurrentTags().concat("Fatal");
     }
 
     this.managePayload(payload);

--- a/sdk/src/CrashReporter.ts
+++ b/sdk/src/CrashReporter.ts
@@ -227,7 +227,7 @@ export default class CrashReporter {
   }
 
   /**
-   * Processes a manually sent error (using local tags, not global).
+   * Processes a manually sent error (using local tags).
    * @param error - The Error to be processed.
    * @param details
    */

--- a/sdk/src/RaygunClient.ts
+++ b/sdk/src/RaygunClient.ts
@@ -192,10 +192,10 @@ const clearBreadcrumbs = () => {
  * 3)   RaygunClient.sendError(new Error(), "Foo", "Bar");
  *
  * @param error - The error.
- * @param params - Custom data or tags alongside the error.
+ * @param params
  * @see CustomData
  */
-const sendError = async (error: Error, ...params: any) => {
+const sendError = async (error: Error, ...params: any[]) => {
   if (!crashReportingAvailable('sendError')) return;
   await crashReporter.processManualCrashReport(error, params);
 };

--- a/sdk/src/RaygunClient.ts
+++ b/sdk/src/RaygunClient.ts
@@ -12,7 +12,7 @@ import {
   anonUser,
   Breadcrumb
 } from './Types';
-import { getCurrentTags, getDeviceBasedId, log, setCurrentTags, setCurrentUser, getCurrentUser, warn } from './Utils';
+import { getCurrentTags, getDeviceId, log, setCurrentTags, setCurrentUser, getCurrentUser, warn } from './Utils';
 import CrashReporter from './CrashReporter';
 import RealUserMonitor from './RealUserMonitor';
 import { Animated, NativeModules } from 'react-native';

--- a/sdk/src/RaygunClient.ts
+++ b/sdk/src/RaygunClient.ts
@@ -212,17 +212,7 @@ const clearBreadcrumbs = () => {
  */
 const sendError = async (error: Error, ...params: any) => {
   if (!crashReportingAvailable('sendError')) return;
-
-  const [customData, tags] = params.length == 1 && Array.isArray(params[0]) ? [null, params[0]] : params;
-
-  if (customData) {
-    setCustomData(customData as CustomData);
-  }
-  if (tags && tags.length) {
-    setTags(tags);
-  }
-
-  await crashReporter.processUnhandledError(error);
+  await crashReporter.processManualCrashReport(error, params);
 };
 
 /**

--- a/sdk/src/RaygunClient.ts
+++ b/sdk/src/RaygunClient.ts
@@ -10,7 +10,7 @@ import {
   RealUserMonitoringTimings,
   BeforeSendHandler,
   anonUser,
-  Breadcrumb
+  Breadcrumb, ManualCrashReportDetails
 } from './Types';
 import { getCurrentTags, getDeviceId, log, setCurrentTags, setCurrentUser, getCurrentUser, warn } from './Utils';
 import CrashReporter from './CrashReporter';
@@ -192,12 +192,12 @@ const clearBreadcrumbs = () => {
  * 3)   RaygunClient.sendError(new Error(), "Foo", "Bar");
  *
  * @param error - The error.
- * @param params
+ * @param details
  * @see CustomData
  */
-const sendError = async (error: Error, ...params: any[]) => {
+const sendError = async (error: Error, details?: ManualCrashReportDetails) => {
   if (!crashReportingAvailable('sendError')) return;
-  await crashReporter.processManualCrashReport(error, params);
+  await crashReporter.processManualCrashReport(error, details);
 };
 
 /**

--- a/sdk/src/RealUserMonitor.ts
+++ b/sdk/src/RealUserMonitor.ts
@@ -5,7 +5,7 @@ import {
   RequestMeta,
   User
 } from './Types';
-import { getDeviceBasedId, log, warn, shouldIgnore, getCurrentUser, getCurrentTags, getRandomGUID } from './Utils';
+import { getDeviceId, log, warn, shouldIgnore, getCurrentUser, getCurrentTags, getRandomGUID } from './Utils';
 // @ts-ignore
 import XHRInterceptor from 'react-native/Libraries/Network/XHRInterceptor';
 import { NativeEventEmitter, NativeModules, Platform } from 'react-native';
@@ -163,7 +163,7 @@ export default class RealUserMonitor {
     const { name, duration } = payload;
 
     if (!this.RealUserMonitoringSessionId) {
-      this.RealUserMonitoringSessionId = getDeviceBasedId();
+      this.RealUserMonitoringSessionId = getDeviceId();
       await this.transmitRealUserMonitoringEvent(RealUserMonitoringEvents.SessionStart, {});
     }
     const data = { name, timing: { type: RealUserMonitoringTimings.ViewLoaded, duration } };
@@ -241,7 +241,7 @@ export default class RealUserMonitor {
       return;
     }
     // Obtain the device ID
-    const id = getDeviceBasedId();
+    const id = getDeviceId();
 
     // Set the ID of the XHRInterceptor to the device ID
     xhr._id_ = id;

--- a/sdk/src/RealUserMonitor.ts
+++ b/sdk/src/RealUserMonitor.ts
@@ -27,7 +27,7 @@ export default class RealUserMonitor {
   private readonly disableNetworkMonitoring: boolean;
   private readonly ignoredURLs: string[];
   private requests = new Map<string, RequestMeta>();
-  private RAYGUN_RUM_ENDPOINT = 'https://api.raygun.com/events';
+  private raygunRumEndpoint = 'https://api.raygun.com/events';
 
   lastSessionInteractionTime = Date.now();
   RealUserMonitoringSessionId: string = ''; //The id for generated RUM Timing events to be grouped under
@@ -54,7 +54,7 @@ export default class RealUserMonitor {
     this.ignoredURLs = ignoredURLs.concat(defaultURLIgnoreList, customRealUserMonitoringEndpoint || []);
 
     if (customRealUserMonitoringEndpoint && customRealUserMonitoringEndpoint.length > 0){
-      this.RAYGUN_RUM_ENDPOINT = customRealUserMonitoringEndpoint;
+      this.raygunRumEndpoint = customRealUserMonitoringEndpoint;
     }
 
     // If the USER has not defined disabling network monitoring, setup the XHRInterceptor (see
@@ -210,7 +210,7 @@ export default class RealUserMonitor {
 
     const rumMessage = this.generateRealUserMonitorPayload(eventName, data, timeAt);
 
-    return fetch(this.RAYGUN_RUM_ENDPOINT + '?apiKey=' + encodeURIComponent(this.apiKey),
+    return fetch(this.raygunRumEndpoint + '?apiKey=' + encodeURIComponent(this.apiKey),
       {
         method: 'POST',
         headers: {

--- a/sdk/src/RealUserMonitor.ts
+++ b/sdk/src/RealUserMonitor.ts
@@ -25,7 +25,6 @@ export default class RealUserMonitor {
   private readonly apiKey: string;
   private readonly version: string;
   private readonly disableNetworkMonitoring: boolean;
-  private readonly customRealUserMonitoringEndpoint: string;
   private readonly ignoredURLs: string[];
   private requests = new Map<string, RequestMeta>();
   private RAYGUN_RUM_ENDPOINT = 'https://api.raygun.com/events';
@@ -51,9 +50,12 @@ export default class RealUserMonitor {
     // Assign the values parsed in (assuming initiation is the only time these are altered).
     this.apiKey = apiKey;
     this.disableNetworkMonitoring = disableNetworkMonitoring;
-    this.customRealUserMonitoringEndpoint = customRealUserMonitoringEndpoint;
     this.version = version;
     this.ignoredURLs = ignoredURLs.concat(defaultURLIgnoreList, customRealUserMonitoringEndpoint || []);
+
+    if (customRealUserMonitoringEndpoint && customRealUserMonitoringEndpoint.length > 0){
+      this.RAYGUN_RUM_ENDPOINT = customRealUserMonitoringEndpoint;
+    }
 
     // If the USER has not defined disabling network monitoring, setup the XHRInterceptor (see
     // NetworkMonitor.ts).
@@ -208,8 +210,7 @@ export default class RealUserMonitor {
 
     const rumMessage = this.generateRealUserMonitorPayload(eventName, data, timeAt);
 
-    return fetch(
-      this.customRealUserMonitoringEndpoint || this.RAYGUN_RUM_ENDPOINT + '?apiKey=' + encodeURIComponent(this.apiKey),
+    return fetch(this.RAYGUN_RUM_ENDPOINT + '?apiKey=' + encodeURIComponent(this.apiKey),
       {
         method: 'POST',
         headers: {

--- a/sdk/src/RealUserMonitor.ts
+++ b/sdk/src/RealUserMonitor.ts
@@ -112,7 +112,6 @@ export default class RealUserMonitor {
    * Updates the time since last activity to be NOW.
    */
   markSessionInteraction() {
-    log('MARK LAST ACTIVE TIME');
     this.lastSessionInteractionTime = Date.now();
   }
 

--- a/sdk/src/RealUserMonitor.ts
+++ b/sdk/src/RealUserMonitor.ts
@@ -129,7 +129,7 @@ export default class RealUserMonitor {
    */
   sendCustomRUMEvent(eventType: RealUserMonitoringTimings, name: string, duration: number) {
     if (eventType === RealUserMonitoringTimings.ViewLoaded) {
-      this.sendViewLoadedEvent({ duration: duration, name: name });
+      this.sendViewLoadedEvent({ name, duration });
       return;
     }
     if (eventType === RealUserMonitoringTimings.NetworkCall) {

--- a/sdk/src/Types.ts
+++ b/sdk/src/Types.ts
@@ -1,6 +1,11 @@
 import { ErrorUtils } from 'react-native';
 import { getDeviceId } from './Utils';
 
+export const anonUser: User = {
+  identifier: `${getDeviceId()}`,
+  isAnonymous: true
+};
+
 //#region ----RAYGUN CLIENT SESSION TYPES-----------------------------------------------------------
 
 export type RaygunClientOptions = {
@@ -29,11 +34,6 @@ export type User = {
   firstName?: string;
   fullName?: string;
   uuid?: string;
-};
-
-export const anonUser: User = {
-  identifier: `${getDeviceId()}`,
-  isAnonymous: true
 };
 
 //#endregion----------------------------------------------------------------------------------------

--- a/sdk/src/Types.ts
+++ b/sdk/src/Types.ts
@@ -104,6 +104,14 @@ export type CrashReportPayload = {
   };
 };
 
+export type ManualCrashReportDetails = {
+  customData?: CustomData,
+  tags?: string[]
+}
+
+
+
+
 //#endregion----------------------------------------------------------------------------------------
 
 //#region ----REAL USER MONITORING SPECIFIC TYPES---------------------------------------------------

--- a/sdk/src/Types.ts
+++ b/sdk/src/Types.ts
@@ -1,5 +1,5 @@
 import { ErrorUtils } from 'react-native';
-import { getDeviceBasedId } from './Utils';
+import { getDeviceId } from './Utils';
 
 //#region ----RAYGUN CLIENT SESSION TYPES-----------------------------------------------------------
 
@@ -32,7 +32,7 @@ export type User = {
 };
 
 export const anonUser: User = {
-  identifier: `${getDeviceBasedId()}`,
+  identifier: `${getDeviceId()}`,
   isAnonymous: true
 };
 

--- a/sdk/src/Utils.ts
+++ b/sdk/src/Utils.ts
@@ -10,10 +10,6 @@ let currentUser: User = anonUser;
 let currentTags: string[] = [];
 
 export const setCurrentUser = (newUser: User) => {
-  if (!newUser){
-    currentUser = {...anonUser};
-    return;
-  }
   currentUser = { ...newUser };
 };
 

--- a/sdk/src/Utils.ts
+++ b/sdk/src/Utils.ts
@@ -39,7 +39,7 @@ export const getCurrentTags = (): string[] => {
 /**
  * Constructs an ID specific for the current device being used.
  */
-export const getDeviceBasedId = () => `${RaygunNativeBridge.DEVICE_ID}`;
+export const getDeviceId = () => `${RaygunNativeBridge.DEVICE_ID}`;
 
 /**
  * Produce a random identifier of a certain length.

--- a/sdk/src/Utils.ts
+++ b/sdk/src/Utils.ts
@@ -10,10 +10,17 @@ let currentUser: User = anonUser;
 let currentTags: string[] = [];
 
 export const setCurrentUser = (newUser: User) => {
+  if (!newUser){
+    currentUser = {...anonUser};
+    return;
+  }
   currentUser = { ...newUser };
 };
 
 export const getCurrentUser = (): User => {
+  if (!currentUser){
+    currentUser = {...anonUser}
+  }
   return { ...currentUser };
 };
 

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -20,6 +20,7 @@ import {
   CrashReportPayload,
   CustomData,
   Environment,
+  ManualCrashReportDetails,
   RaygunClientOptions,
   RaygunStackFrame,
   RealUserMonitoringTimings,
@@ -48,6 +49,7 @@ export type {
   CrashReportPayload,
   CustomData,
   Environment,
+  ManualCrashReportDetails,
   RaygunClientOptions,
   RaygunStackFrame,
   User


### PR DESCRIPTION
This PR makes some changes to the provider with no connecting theme. They're all small changes that were deemed to small to care about at the time of notice.

Changes Made:
- Rejections are now being caught and sent to Raygun.com
- The currentUser is not being set to the anonUser object on initialization. Some fail safes have been put in place to ensure user is always an instance of a user object.
- RaygunClinet.sendError was not separating custom data and tags from the params, this issue has been fixed.
- { "name" : name, "duration" duration } changed to { name, duration }
- getDeviceBaseId changed to getDeviceId
- RAYGUN_ENDPOINT's change to raygunEndpoint's