### PR TITLE
Restrict the number of breadcrumbs a report can have

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ const options: RaygunClientOptions = {
   ignoredViews: ["name of view to ignore"],
   logLevel: LogLevel.verbose,
   onBeforeSendingCrashReport: (crashReport) => console.log(crashReport),
+  maxErrorReportsStoredOnDevice: 10,
+  maxBreadCrumbsPerErrorReport: 10,
 };
 
 RaygunClient.init(options);
@@ -678,6 +680,8 @@ export type RaygunClientOptions = {
   onBeforeSendingCrashReport?: BeforeSendHandler;
   ignoredURLs?: string[];
   ignoredViews?: string[];
+  maxErrorReportsStoredOnDevice?: number;
+  maxBreadcrumbsPerErrorReport?: number;
 };
 ```
 

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raygun4reactnative",
   "title": "Raygun4reactnative",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Raygun React Native SDK",
   "main": "dist/index.js",
   "typescript": {

--- a/sdk/src/CrashReporter.ts
+++ b/sdk/src/CrashReporter.ts
@@ -16,7 +16,7 @@ const {version: clientVersion} = require('../package.json');
 export default class CrashReporter {
   //#region ----INITIALIZATION----------------------------------------------------------------------
 
-  public static readonly MAX_ERROR_REPORTS_STORED_LOCALLY = 64;
+  public static readonly MAX_ERROR_REPORTS_STORED_ON_DEVICE = 64;
   public static readonly MAX_BREADCRUMBS_PER_ERROR_REPORT = 32;
 
   private readonly LOCAL_STORAGE_KEY = 'raygun4reactnative_local_storage';
@@ -29,7 +29,7 @@ export default class CrashReporter {
   private disableNativeCrashReporting: boolean;
   private onBeforeSendingCrashReport: BeforeSendHandler | null;
   private raygunCrashReportEndpoint = 'https://api.raygun.com/entries';
-  private maxLocallyStoredErrorReports: number;
+  private maxErrorReportsStoredOnDevice: number;
   private maxBreadcrumbsPerErrorReport: number;
 
   /**
@@ -60,7 +60,7 @@ export default class CrashReporter {
     this.disableNativeCrashReporting = disableNativeCrashReporting;
     this.onBeforeSendingCrashReport = onBeforeSendingCrashReport;
     this.version = version;
-    this.maxLocallyStoredErrorReports = Math.min(Math.max(maxErrorReportsStoredOnDevice, 0), CrashReporter.MAX_ERROR_REPORTS_STORED_LOCALLY);
+    this.maxErrorReportsStoredOnDevice = Math.min(Math.max(maxErrorReportsStoredOnDevice, 0), CrashReporter.MAX_ERROR_REPORTS_STORED_ON_DEVICE);
     this.maxBreadcrumbsPerErrorReport = Math.min(Math.max(maxBreadCrumbsPerErrorReport, 0), CrashReporter.MAX_BREADCRUMBS_PER_ERROR_REPORT);
 
     if (customCrashReportingEndpoint && customCrashReportingEndpoint.length > 0) {
@@ -197,8 +197,8 @@ export default class CrashReporter {
     let appendedCache : CrashReportPayload[] = (await this.getCachedCrashReports()).concat(reports);
 
     //If the cache is already full then ignore this report
-    if (appendedCache.length >= this.maxLocallyStoredErrorReports) {
-      appendedCache = appendedCache.slice(0, this.maxLocallyStoredErrorReports);
+    if (appendedCache.length >= this.maxErrorReportsStoredOnDevice) {
+      appendedCache = appendedCache.slice(0, this.maxErrorReportsStoredOnDevice);
     }
 
     await this.setCachedCrashReports(appendedCache);
@@ -227,12 +227,12 @@ export default class CrashReporter {
    */
   async setMaxReportsStoredOnDevice(newSize: number) {
     //Set the maximum keeping between a range of [0, 64]
-    this.maxLocallyStoredErrorReports = Math.min(Math.max(newSize, 0), CrashReporter.MAX_ERROR_REPORTS_STORED_LOCALLY);
+    this.maxErrorReportsStoredOnDevice = Math.min(Math.max(newSize, 0), CrashReporter.MAX_ERROR_REPORTS_STORED_ON_DEVICE);
 
     //Remove excess cached reports where necessary, prioritising older reports
     let cache : CrashReportPayload[] = await this.getCachedCrashReports();
-    if (cache.length > this.maxLocallyStoredErrorReports) {
-      await this.setCachedCrashReports(cache.slice(0, this.maxLocallyStoredErrorReports));
+    if (cache.length > this.maxErrorReportsStoredOnDevice) {
+      await this.setCachedCrashReports(cache.slice(0, this.maxErrorReportsStoredOnDevice));
     }
   }
 

--- a/sdk/src/CrashReporter.ts
+++ b/sdk/src/CrashReporter.ts
@@ -16,6 +16,12 @@ const {version: clientVersion} = require('../package.json');
 export default class CrashReporter {
   //#region ----INITIALIZATION----------------------------------------------------------------------
 
+  public static readonly MAX_ERROR_REPORTS_STORED_LOCALLY = 64;
+  public static readonly MAX_BREADCRUMBS_PER_ERROR_REPORT = 32;
+
+  private readonly LOCAL_STORAGE_KEY = 'raygun4reactnative_local_storage';
+  private readonly RAYGUN_RATE_LIMITING_STATUS_CODE = 429;
+
   private breadcrumbs: Breadcrumb[] = [];
   private customData: CustomData = {};
   private apiKey: string;
@@ -23,10 +29,8 @@ export default class CrashReporter {
   private disableNativeCrashReporting: boolean;
   private onBeforeSendingCrashReport: BeforeSendHandler | null;
   private raygunCrashReportEndpoint = 'https://api.raygun.com/entries';
-
-  private local_storage_key : string = "raygun4reactnative_local_storage";
-  private readonly RAYGUN_RATE_LIMITING_STATUS_CODE : number = 429;
-  private maxLocallyStoredCrashReports : number = 64;
+  private maxLocallyStoredErrorReports: number;
+  private maxBreadcrumbsPerErrorReport: number;
 
   /**
    * Initialise Javascript side error/promise rejection handlers and identify whether the Native or
@@ -38,6 +42,8 @@ export default class CrashReporter {
    * @param customCrashReportingEndpoint - Custom endpoint for Crash Report (may be empty or null)
    * @param onBeforeSendingCrashReport - A lambda to execute before each Crash Report transmission
    * @param version - The current version of the RaygunClient
+   * @param maxErrorReportsStoredOnDevice - The total number of error reports that can be in local storage at one time
+   * @param maxBreadCrumbsPerErrorReport - The total number of breadcrumbs an error report can contain
    */
   constructor(
     apiKey: string,
@@ -45,13 +51,17 @@ export default class CrashReporter {
     disableUnhandledPromiseRejectionReporting: boolean,
     customCrashReportingEndpoint: string,
     onBeforeSendingCrashReport: BeforeSendHandler | null,
-    version: string
+    version: string,
+    maxErrorReportsStoredOnDevice: number,
+    maxBreadCrumbsPerErrorReport: number,
   ) {
     // Assign the values parsed in (assuming initiation is the only time these are altered).
     this.apiKey = apiKey;
     this.disableNativeCrashReporting = disableNativeCrashReporting;
     this.onBeforeSendingCrashReport = onBeforeSendingCrashReport;
     this.version = version;
+    this.maxLocallyStoredErrorReports = Math.min(Math.max(maxErrorReportsStoredOnDevice, 0), CrashReporter.MAX_ERROR_REPORTS_STORED_LOCALLY);
+    this.maxBreadcrumbsPerErrorReport = Math.min(Math.max(maxBreadCrumbsPerErrorReport, 0), CrashReporter.MAX_BREADCRUMBS_PER_ERROR_REPORT);
 
     if (customCrashReportingEndpoint && customCrashReportingEndpoint.length > 0) {
       this.raygunCrashReportEndpoint = customCrashReportingEndpoint;
@@ -116,6 +126,11 @@ export default class CrashReporter {
    */
   recordBreadcrumb(breadcrumb: Breadcrumb) {
     this.breadcrumbs.push({...breadcrumb});
+
+    if (this.breadcrumbs.length > this.maxBreadcrumbsPerErrorReport) {
+      this.breadcrumbs.shift();
+    }
+
     if (!this.disableNativeCrashReporting) {
       RaygunNativeBridge.recordBreadcrumb(breadcrumb);
     }
@@ -147,7 +162,7 @@ export default class CrashReporter {
    */
   async getCachedCrashReports() : Promise<CrashReportPayload[]>{
     try {
-      const rawCache = await AsyncStorage.getItem(this.local_storage_key)
+      const rawCache = await AsyncStorage.getItem(this.LOCAL_STORAGE_KEY);
       if(rawCache !== null) {
         try {
           return JSON.parse(rawCache);
@@ -168,7 +183,7 @@ export default class CrashReporter {
    */
   async setCachedCrashReports(newCache : CrashReportPayload[]) {
     try {
-      await AsyncStorage.setItem(this.local_storage_key, JSON.stringify(newCache));
+      await AsyncStorage.setItem(this.LOCAL_STORAGE_KEY, JSON.stringify(newCache));
     } catch(e) {
       RaygunLogger.e("Unable to access local storage");
     }
@@ -182,8 +197,8 @@ export default class CrashReporter {
     let appendedCache : CrashReportPayload[] = (await this.getCachedCrashReports()).concat(reports);
 
     //If the cache is already full then ignore this report
-    if (appendedCache.length >= this.maxLocallyStoredCrashReports) {
-      appendedCache = appendedCache.slice(0, this.maxLocallyStoredCrashReports);
+    if (appendedCache.length >= this.maxLocallyStoredErrorReports) {
+      appendedCache = appendedCache.slice(0, this.maxLocallyStoredErrorReports);
     }
 
     await this.setCachedCrashReports(appendedCache);
@@ -212,12 +227,12 @@ export default class CrashReporter {
    */
   async setMaxReportsStoredOnDevice(newSize: number) {
     //Set the maximum keeping between a range of [0, 64]
-    this.maxLocallyStoredCrashReports = Math.min(Math.max(newSize, 0), 64)
+    this.maxLocallyStoredErrorReports = Math.min(Math.max(newSize, 0), CrashReporter.MAX_ERROR_REPORTS_STORED_LOCALLY);
 
     //Remove excess cached reports where necessary, prioritising older reports
     let cache : CrashReportPayload[] = await this.getCachedCrashReports();
-    if (cache.length > this.maxLocallyStoredCrashReports) {
-      await this.setCachedCrashReports(cache.slice(0, this.maxLocallyStoredCrashReports));
+    if (cache.length > this.maxLocallyStoredErrorReports) {
+      await this.setCachedCrashReports(cache.slice(0, this.maxLocallyStoredErrorReports));
     }
   }
 

--- a/sdk/src/RaygunClient.ts
+++ b/sdk/src/RaygunClient.ts
@@ -66,7 +66,7 @@ const init = (raygunClientOptions: RaygunClientOptions) => {
         onBeforeSendingCrashReport = null,
         ignoredURLs = [],
         ignoredViews = [],
-        maxErrorReportsStoredOnDevice = CrashReporter.MAX_ERROR_REPORTS_STORED_LOCALLY,
+        maxErrorReportsStoredOnDevice = CrashReporter.MAX_ERROR_REPORTS_STORED_ON_DEVICE,
         maxBreadcrumbsPerErrorReport = CrashReporter.MAX_BREADCRUMBS_PER_ERROR_REPORT,
     } = options;
 

--- a/sdk/src/RaygunClient.ts
+++ b/sdk/src/RaygunClient.ts
@@ -65,7 +65,9 @@ const init = (raygunClientOptions: RaygunClientOptions) => {
         logLevel = LogLevel.warn,
         onBeforeSendingCrashReport = null,
         ignoredURLs = [],
-        ignoredViews = []
+        ignoredViews = [],
+        maxErrorReportsStoredOnDevice = CrashReporter.MAX_ERROR_REPORTS_STORED_LOCALLY,
+        maxBreadcrumbsPerErrorReport = CrashReporter.MAX_BREADCRUMBS_PER_ERROR_REPORT,
     } = options;
 
     RaygunLogger.init(logLevel);
@@ -80,7 +82,9 @@ const init = (raygunClientOptions: RaygunClientOptions) => {
             disableUnhandledPromiseRejectionReporting,
             customCrashReportingEndpoint || '',
             onBeforeSendingCrashReport as BeforeSendHandler,
-            version
+            version,
+            maxErrorReportsStoredOnDevice,
+            maxBreadcrumbsPerErrorReport,
         );
 
         if (!disableNativeCrashReporting) {

--- a/sdk/src/Types.ts
+++ b/sdk/src/Types.ts
@@ -16,6 +16,8 @@ export type RaygunClientOptions = {
   onBeforeSendingCrashReport?: BeforeSendHandler;
   ignoredURLs?: string[];
   ignoredViews?: string[];
+  maxErrorReportsStoredOnDevice?: number;
+  maxBreadcrumbsPerErrorReport?: number;
 };
 
 export enum LogLevel {


### PR DESCRIPTION
Changes:
- Set an upper limit of breadcrumbs a report can contain (max 32)
- Expose client option to set the max number of reports that can be stored locally