### PR TITLE
Ensure the ignore lists are applied to RUM events

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raygun4reactnative",
   "title": "Raygun4reactnative",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Raygun React Native SDK",
   "main": "dist/index.js",
   "typescript": {

--- a/sdk/src/RaygunClient.ts
+++ b/sdk/src/RaygunClient.ts
@@ -86,11 +86,10 @@ const init = (raygunClientOptions: RaygunClientOptions) => {
       disableNativeCrashReporting,
       disableUnhandledPromiseRejectionReporting,
       customCrashReportingEndpoint || '',
-            onBeforeSendingCrashReport as BeforeSendHandler,
-            version,
-            maxErrorReportsStoredOnDevice,
-            maxBreadcrumbsPerErrorReport,
-    );
+      onBeforeSendingCrashReport as BeforeSendHandler,
+      version,
+      maxErrorReportsStoredOnDevice,
+      maxBreadcrumbsPerErrorReport);
 
     if (!disableNativeCrashReporting) {
       RaygunNativeBridge.initCrashReportingNativeSupport(apiKey, version, customCrashReportingEndpoint);
@@ -105,8 +104,7 @@ const init = (raygunClientOptions: RaygunClientOptions) => {
       ignoredURLs,
       ignoredViews,
       customRealUserMonitoringEndpoint,
-      version,
-    );
+      version);
 
     // Add the lifecycle event listeners to the bridge.
     RaygunNativeBridge.initRealUserMonitoringNativeSupport();

--- a/sdk/src/Utils.ts
+++ b/sdk/src/Utils.ts
@@ -108,15 +108,4 @@ export const noAddressAt = ({methodName, ...rest}: StackFrame): StackFrame => {
   };
 };
 
-export const removeProtocol = (url: string) => url.replace(/^http(s)?:\/\//i, '');
-
-export const shouldIgnoreURL = (url: string, ignoredURLs: string[]): boolean => {
-  const target = removeProtocol(url);
-  return ignoredURLs.some((ignored) => target.startsWith(ignored));
-};
-
-export const shouldIgnoreView = (name: string, ignoredViews: string[]): boolean => {
-  return ignoredViews.some((ignored) => name.startsWith(ignored));
-};
-
 export const filterOutReactFrames = (frame: StackFrame): boolean => !!frame.file && !frame.file.match(internalTrace);


### PR DESCRIPTION
Changes:
- moved the *should ignore* view or URL methods into the RUM class
- perform *should ignore* check when manually reporting network timing events
- changed the comparison from a `startsWith` to an `includes` operation
- no longer remove protocols when comparing URLs
- a little bit of code formatting