### PR TITLE
[SUP-329] Do not access modules before the React context is ready

### DIFF
--- a/sdk/android/src/main/java/com/raygun/react/RaygunNativeBridgeModule.java
+++ b/sdk/android/src/main/java/com/raygun/react/RaygunNativeBridgeModule.java
@@ -221,6 +221,11 @@ public class RaygunNativeBridgeModule extends ReactContextBaseJavaModule impleme
      * @param payload   - A WritableMap of information to be parsed with this event's occurence.
      */
     private void sendJSEvent(String eventType, @Nullable WritableMap payload) {
+        if (reactContext == null || !reactContext.hasActiveCatalystInstance()) {
+          Log.w("Raygun", "Unable to send JS event for " + eventType + " due to inactive React context.");
+          return;
+        }
+
         reactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class).emit(eventType, payload);
     }
 

--- a/sdk/android/src/main/java/com/raygun/react/RaygunNativeBridgeModule.java
+++ b/sdk/android/src/main/java/com/raygun/react/RaygunNativeBridgeModule.java
@@ -222,7 +222,7 @@ public class RaygunNativeBridgeModule extends ReactContextBaseJavaModule impleme
      */
     private void sendJSEvent(String eventType, @Nullable WritableMap payload) {
         if (reactContext == null || !reactContext.hasActiveCatalystInstance()) {
-          Log.w("Raygun", "Unable to send JS event for " + eventType + " due to inactive React context.");
+          Log.w("Raygun", "Unable to send JS event for " + eventType + " due to an inactive React context.");
           return;
         }
 

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raygun4reactnative",
   "title": "Raygun4reactnative",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Raygun React Native SDK",
   "main": "dist/index.js",
   "typescript": {


### PR DESCRIPTION
Fixing a runtime exception that can occur when we record lifecycle events before the React context is available to us.