### PR TITLE
Fix native crash reports failing to send

### DIFF
--- a/sdk/src/CrashReporter.ts
+++ b/sdk/src/CrashReporter.ts
@@ -16,6 +16,7 @@ const {version: clientVersion} = require('../package.json');
 export default class CrashReporter {
   public static readonly MAX_ERROR_REPORTS_STORED_ON_DEVICE = 64;
   public static readonly MAX_BREADCRUMBS_PER_ERROR_REPORT = 32;
+  public static readonly DEFAULT_RAYGUN_CRASH_REPORTING_ENDPOINT = 'https://api.raygun.com/entries';
 
   private readonly LOCAL_STORAGE_KEY = 'raygun4reactnative_local_storage';
   private readonly RAYGUN_RATE_LIMITING_STATUS_CODE = 429;
@@ -26,7 +27,7 @@ export default class CrashReporter {
   private version: string;
   private disableNativeCrashReporting: boolean;
   private onBeforeSendingCrashReport: BeforeSendHandler | null;
-  private raygunCrashReportEndpoint = 'https://api.raygun.com/entries';
+  private raygunCrashReportEndpoint = CrashReporter.DEFAULT_RAYGUN_CRASH_REPORTING_ENDPOINT;
   private maxErrorReportsStoredOnDevice: number;
   private maxBreadcrumbsPerErrorReport: number;
 

--- a/sdk/src/RaygunClient.ts
+++ b/sdk/src/RaygunClient.ts
@@ -92,7 +92,11 @@ const init = (raygunClientOptions: RaygunClientOptions) => {
       maxBreadcrumbsPerErrorReport);
 
     if (!disableNativeCrashReporting) {
-      RaygunNativeBridge.initCrashReportingNativeSupport(apiKey, version, customCrashReportingEndpoint);
+      RaygunNativeBridge.initCrashReportingNativeSupport(
+        apiKey,
+        version,
+        customCrashReportingEndpoint || CrashReporter.DEFAULT_RAYGUN_CRASH_REPORTING_ENDPOINT,
+      );
     }
   }
 


### PR DESCRIPTION
raygun4apple requires us to pass in an endpoint. Previously, we would
only pass in the custom endpoint provided by the user, which would
effectively disable native crash reporting unless a custom endpoint was
used.

Now, we pass in the default Raygun endpoint if we have no custom
endpoint available. This allows native exceptions to be reported as
expected.