### PR TITLE
Bumped version to 1.1.6 for release purposes.

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raygun4reactnative",
   "title": "Raygun4reactnative",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Raygun React Native SDK",
   "main": "dist/index.js",
   "typescript": {


### PR DESCRIPTION
This PR simply bumps the version number so we can release a new version following the merge of this bug fix: https://github.com/MindscapeHQ/raygun4reactnative/pull/53