### PR TITLE
Remove unused javadoc generation from build.gradle

### DIFF
--- a/sdk/android/build.gradle
+++ b/sdk/android/build.gradle
@@ -84,18 +84,6 @@ dependencies {
 afterEvaluate { project ->
     // some Gradle build hooks ref:
     // https://www.oreilly.com/library/view/gradle-beyond-the/9781449373801/ch03.html
-    task androidJavadoc(type: Javadoc) {
-        source = android.sourceSets.main.java.srcDirs
-        classpath += files(android.bootClasspath)
-        classpath += files(project.getConfigurations().getByName('compile').asList())
-        include '**/*.java'
-    }
-
-    task androidJavadocJar(type: Jar, dependsOn: androidJavadoc) {
-        archiveClassifier = 'javadoc'
-        from androidJavadoc.destinationDir
-    }
-
     task androidSourcesJar(type: Jar) {
         archiveClassifier = 'sources'
         from android.sourceSets.main.java.srcDirs


### PR DESCRIPTION
This code is historic, but was never actually used to generate javadocs.

It's now causing build issues in the event that the compile configuration can't be found.

Since this doesn't actually do anything, it should be fine for us to remove it.