### PR TITLE
Bumped version to 1.2.1 for release

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raygun4reactnative",
   "title": "Raygun4reactnative",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Raygun React Native SDK",
   "main": "dist/index.js",
   "typescript": {


### PR DESCRIPTION
Bumps version to 1.2.1 to release a new version of the provider featuring this bug fix: https://github.com/MindscapeHQ/raygun4reactnative/pull/58