### PR TITLE
Fix undefined Promise.prototype.finally when using promise rejection tracking

### DIFF
--- a/sdk/src/CrashReporter.ts
+++ b/sdk/src/CrashReporter.ts
@@ -81,6 +81,8 @@ export default class CrashReporter {
       const {polyfillGlobal} = require('react-native/Libraries/Utilities/PolyfillFunctions');
       const Promise = require('promise/setimmediate/es6-extensions');
       const tracking = require('promise/setimmediate/rejection-tracking');
+      require('promise/setimmediate/done');
+      require('promise/setimmediate/finally');
 
       // Set up rejection handler to divert rejections to crash reporter
       polyfillGlobal('Promise', () => {


### PR DESCRIPTION
When tracking unhandled Promise rejections, we polyfill the Promise global.
The `promise` polyfill module is split into a number of submodules, that
implement different parts of the Promise specification.

As we were only requiring es6-extensions, Promise.prototype.finally and
Promise.prototype.done were not defined. We can fix this by requiring
the done and finally implementations from the `promise` module.

Fixes #42 