### PR TITLE
patching react native dependencies

### DIFF
--- a/demo/android/build.gradle
+++ b/demo/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath("com.android.tools.build:gradle:3.5.3")
@@ -31,7 +31,7 @@ allprojects {
         }
 
         google()
-        jcenter()
+        mavenCentral()
         maven { url 'https://www.jitpack.io' }
     }
 }

--- a/sdk/android/build.gradle
+++ b/sdk/android/build.gradle
@@ -30,7 +30,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
+            mavenCentral()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -71,7 +71,7 @@ repositories {
         url "$rootDir/../lib"
     }
     google()
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
this PR will remove jcenter() from all the dependencies during config phase and replace it with mavenCentral()