### PR TITLE
Patched iOS XCTest issue

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -1,14 +1,24 @@
 import * as React from 'react';
-import {NavigationContainer} from "@react-navigation/native";
-import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
+import { NavigationContainer } from "@react-navigation/native";
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import Home from "./screens/Home";
 import CrashReporting from "./screens/CrashReporting";
 import RealUserMonitoring from "./screens/RealUserMonitoring";
-import {raygunClient} from "./utils/Utils";
-import {LogLevel, RaygunClientOptions} from "raygun4reactnative";
+import { raygunClient } from "./utils/Utils";
+import { LogLevel, RaygunClientOptions } from "raygun4reactnative";
 
 
 //#region -- REACT-NATIVE APPLICATION SETUP --------------------------------------------------------
+
+/*//------------- Application testing setup -------------
+//TODO: move to test initialization
+const options: RaygunClientOptions = {
+  apiKey: 'e5cxkTF9wHpIYxVaxvx6Ig',
+  enableCrashReporting: true,
+  enableRealUserMonitoring: true,
+}
+raygunClient.init(options);
+//------------- End application testing setup -------------*/
 
 const Tab = createBottomTabNavigator();
 
@@ -45,7 +55,7 @@ function Tabs() {
 export default function App() {
   return (
     <NavigationContainer>
-      <Tabs/>
+      <Tabs />
     </NavigationContainer>
   );
 }

--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
-import { NavigationContainer } from "@react-navigation/native";
-import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import {NavigationContainer} from "@react-navigation/native";
+import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
 import Home from "./screens/Home";
 import CrashReporting from "./screens/CrashReporting";
 import RealUserMonitoring from "./screens/RealUserMonitoring";
-import { raygunClient } from "./utils/Utils";
-import { LogLevel, RaygunClientOptions } from "raygun4reactnative";
+import {raygunClient} from "./utils/Utils";
+import {LogLevel, RaygunClientOptions} from "raygun4reactnative";
 
 
 //#region -- REACT-NATIVE APPLICATION SETUP --------------------------------------------------------
@@ -13,7 +13,7 @@ import { LogLevel, RaygunClientOptions } from "raygun4reactnative";
 /*//------------- Application testing setup -------------
 //TODO: move to test initialization
 const options: RaygunClientOptions = {
-  apiKey: 'e5cxkTF9wHpIYxVaxvx6Ig',
+  apiKey: 'API_KEY_HERE',
   enableCrashReporting: true,
   enableRealUserMonitoring: true,
 }
@@ -55,7 +55,7 @@ function Tabs() {
 export default function App() {
   return (
     <NavigationContainer>
-      <Tabs />
+      <Tabs/>
     </NavigationContainer>
   );
 }

--- a/demo/ios/Podfile
+++ b/demo/ios/Podfile
@@ -17,7 +17,7 @@ target 'Raygun4ReactNativeDemo' do
   #
   # Note that if you have use_frameworks! enabled, Flipper will not work and
   # you should disable these next few lines.
-  use_flipper!
+  use_flipper!({'Flipper' => '0.87.0', 'Flipper-Folly' => '2.5.3', 'Flipper-RSocket' => '1.3.1'})
   post_install do |installer|
     flipper_post_install(installer)
   end

--- a/demo/ios/Raygun4ReactNativeDemo.xcodeproj/project.pbxproj
+++ b/demo/ios/Raygun4ReactNativeDemo.xcodeproj/project.pbxproj
@@ -7,17 +7,17 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		00E356F31AD99517003FC87E /* Raygun4ReactNativeDemoTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* Raygun4ReactNativeDemoTests.m */; };
+		00E356F31AD99517003FC87E /* Raygun4ReactNativeDemo.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* Raygun4ReactNativeDemo.m */; };
 		13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		2D02E4BC1E0B4A80006451C7 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
 		2D02E4BD1E0B4A84006451C7 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		2D02E4BF1E0B4AB3006451C7 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
-		2DCD954D1E0B4F2C00145EB5 /* Raygun4ReactNativeDemoTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* Raygun4ReactNativeDemoTests.m */; };
-		526747A809E9BA47213A69BA /* libPods-Raygun4ReactNativeDemo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 07354E3A14FCFEEE4BD7980C /* libPods-Raygun4ReactNativeDemo.a */; };
+		2DCD954D1E0B4F2C00145EB5 /* Raygun4ReactNativeDemo.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* Raygun4ReactNativeDemo.m */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
-		F8A65AF109B67FAE691BB657 /* libPods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B778E1C317EA9C19E9DC35A /* libPods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests.a */; };
+		9FCBB81B82953BC253EAE9C9 /* libPods-Raygun4ReactNativeDemo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 853B3ADD3BE4E19C9B4151B3 /* libPods-Raygun4ReactNativeDemo.a */; };
+		B04543B55394DF4F7E8356F8 /* libPods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8FE554571A2BE14DDA45772A /* libPods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -38,25 +38,24 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		008F07F21AC5B25A0029DE68 /* main.jsbundle */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = main.jsbundle; sourceTree = "<group>"; };
 		00E356EE1AD99517003FC87E /* Raygun4ReactNativeDemoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Raygun4ReactNativeDemoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		00E356F11AD99517003FC87E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		00E356F21AD99517003FC87E /* Raygun4ReactNativeDemoTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Raygun4ReactNativeDemoTests.m; sourceTree = "<group>"; };
-		07354E3A14FCFEEE4BD7980C /* libPods-Raygun4ReactNativeDemo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Raygun4ReactNativeDemo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		00E356F21AD99517003FC87E /* Raygun4ReactNativeDemo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Raygun4ReactNativeDemo.m; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* Raygun4ReactNativeDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Raygun4ReactNativeDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = Raygun4ReactNativeDemo/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = Raygun4ReactNativeDemo/AppDelegate.m; sourceTree = "<group>"; };
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = Raygun4ReactNativeDemo/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Raygun4ReactNativeDemo/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = Raygun4ReactNativeDemo/main.m; sourceTree = "<group>"; };
+		1B244E18DADBAB27CA8609E9 /* Pods-Raygun4ReactNativeDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Raygun4ReactNativeDemo.release.xcconfig"; path = "Target Support Files/Pods-Raygun4ReactNativeDemo/Pods-Raygun4ReactNativeDemo.release.xcconfig"; sourceTree = "<group>"; };
+		20F6A921881438629D255788 /* Pods-Raygun4ReactNativeDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Raygun4ReactNativeDemo.debug.xcconfig"; path = "Target Support Files/Pods-Raygun4ReactNativeDemo/Pods-Raygun4ReactNativeDemo.debug.xcconfig"; sourceTree = "<group>"; };
 		2D02E47B1E0B4A5D006451C7 /* Raygun4ReactNativeDemo-tvOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Raygun4ReactNativeDemo-tvOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2D02E4901E0B4A5D006451C7 /* Raygun4ReactNativeDemo-tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Raygun4ReactNativeDemo-tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		403E1F325A92EB8CA274AA3A /* Pods-Raygun4ReactNativeDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Raygun4ReactNativeDemo.debug.xcconfig"; path = "Target Support Files/Pods-Raygun4ReactNativeDemo/Pods-Raygun4ReactNativeDemo.debug.xcconfig"; sourceTree = "<group>"; };
-		7B778E1C317EA9C19E9DC35A /* libPods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		7BE3D6708FB21B402ABB9889 /* Pods-Raygun4ReactNativeDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Raygun4ReactNativeDemo.release.xcconfig"; path = "Target Support Files/Pods-Raygun4ReactNativeDemo/Pods-Raygun4ReactNativeDemo.release.xcconfig"; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = Raygun4ReactNativeDemo/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		9996511D045DD20DF4C931C3 /* Pods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests.release.xcconfig"; path = "Target Support Files/Pods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests/Pods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests.release.xcconfig"; sourceTree = "<group>"; };
-		D8404A478DB92E03F795A61A /* Pods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests.debug.xcconfig"; path = "Target Support Files/Pods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests/Pods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests.debug.xcconfig"; sourceTree = "<group>"; };
+		853B3ADD3BE4E19C9B4151B3 /* libPods-Raygun4ReactNativeDemo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Raygun4ReactNativeDemo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		8FE554571A2BE14DDA45772A /* libPods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		A2BC1A504558182E5182367E /* Pods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests.debug.xcconfig"; path = "Target Support Files/Pods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests/Pods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests.debug.xcconfig"; sourceTree = "<group>"; };
+		BD4858C20F9AF545A07B6E7D /* Pods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests.release.xcconfig"; path = "Target Support Files/Pods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests/Pods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests.release.xcconfig"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		ED2971642150620600B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.0.sdk/System/Library/Frameworks/JavaScriptCore.framework; sourceTree = DEVELOPER_DIR; };
 /* End PBXFileReference section */
@@ -66,7 +65,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F8A65AF109B67FAE691BB657 /* libPods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests.a in Frameworks */,
+				B04543B55394DF4F7E8356F8 /* libPods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -74,7 +73,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				526747A809E9BA47213A69BA /* libPods-Raygun4ReactNativeDemo.a in Frameworks */,
+				9FCBB81B82953BC253EAE9C9 /* libPods-Raygun4ReactNativeDemo.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -98,7 +97,7 @@
 		00E356EF1AD99517003FC87E /* Raygun4ReactNativeDemoTests */ = {
 			isa = PBXGroup;
 			children = (
-				00E356F21AD99517003FC87E /* Raygun4ReactNativeDemoTests.m */,
+				00E356F21AD99517003FC87E /* Raygun4ReactNativeDemo.m */,
 				00E356F01AD99517003FC87E /* Supporting Files */,
 			);
 			path = Raygun4ReactNativeDemoTests;
@@ -115,7 +114,6 @@
 		13B07FAE1A68108700A75B9A /* Raygun4ReactNativeDemo */ = {
 			isa = PBXGroup;
 			children = (
-				008F07F21AC5B25A0029DE68 /* main.jsbundle */,
 				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
 				13B07FB01A68108700A75B9A /* AppDelegate.m */,
 				13B07FB51A68108700A75B9A /* Images.xcassets */,
@@ -131,10 +129,21 @@
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
 				ED2971642150620600B7C4FE /* JavaScriptCore.framework */,
-				07354E3A14FCFEEE4BD7980C /* libPods-Raygun4ReactNativeDemo.a */,
-				7B778E1C317EA9C19E9DC35A /* libPods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests.a */,
+				853B3ADD3BE4E19C9B4151B3 /* libPods-Raygun4ReactNativeDemo.a */,
+				8FE554571A2BE14DDA45772A /* libPods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests.a */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		3CB2BFF22962D494963598BD /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				20F6A921881438629D255788 /* Pods-Raygun4ReactNativeDemo.debug.xcconfig */,
+				1B244E18DADBAB27CA8609E9 /* Pods-Raygun4ReactNativeDemo.release.xcconfig */,
+				A2BC1A504558182E5182367E /* Pods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests.debug.xcconfig */,
+				BD4858C20F9AF545A07B6E7D /* Pods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests.release.xcconfig */,
+			);
+			path = Pods;
 			sourceTree = "<group>";
 		};
 		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
@@ -152,7 +161,7 @@
 				00E356EF1AD99517003FC87E /* Raygun4ReactNativeDemoTests */,
 				83CBBA001A601CBA00E9B192 /* Products */,
 				2D16E6871FA4F8E400B85C8A /* Frameworks */,
-				8410BF5A711D5FA69ED918A8 /* Pods */,
+				3CB2BFF22962D494963598BD /* Pods */,
 			);
 			indentWidth = 2;
 			sourceTree = "<group>";
@@ -170,18 +179,6 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		8410BF5A711D5FA69ED918A8 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				403E1F325A92EB8CA274AA3A /* Pods-Raygun4ReactNativeDemo.debug.xcconfig */,
-				7BE3D6708FB21B402ABB9889 /* Pods-Raygun4ReactNativeDemo.release.xcconfig */,
-				D8404A478DB92E03F795A61A /* Pods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests.debug.xcconfig */,
-				9996511D045DD20DF4C931C3 /* Pods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests.release.xcconfig */,
-			);
-			name = Pods;
-			path = Pods;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -189,11 +186,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 00E357021AD99517003FC87E /* Build configuration list for PBXNativeTarget "Raygun4ReactNativeDemoTests" */;
 			buildPhases = (
-				70192FB08FF81B73EC474428 /* [CP] Check Pods Manifest.lock */,
+				BA27287791D9ECD58A2579F4 /* [CP] Check Pods Manifest.lock */,
 				00E356EA1AD99517003FC87E /* Sources */,
 				00E356EB1AD99517003FC87E /* Frameworks */,
 				00E356EC1AD99517003FC87E /* Resources */,
-				2403129A1035622B709331D2 /* [CP] Copy Pods Resources */,
+				3B518DD0A5E066CA7C957DF6 /* [CP] Copy Pods Resources */,
+				1255C69214146F5D3D1A8D6D /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -209,13 +207,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "Raygun4ReactNativeDemo" */;
 			buildPhases = (
-				7FE6F4F320153F2D06436804 /* [CP] Check Pods Manifest.lock */,
+				3B17AC717AA1F324604FBF4C /* [CP] Check Pods Manifest.lock */,
 				FD10A7F022414F080027D42C /* Start Packager */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
-				2B8A7FB383A4254558B065A2 /* [CP] Copy Pods Resources */,
+				DC85596683CA2EDDD521F236 /* [CP] Copy Pods Resources */,
+				33769AAB94CF66BB8ED372B9 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -359,7 +358,79 @@
 			shellPath = /bin/sh;
 			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/scripts/react-native-xcode.sh";
 		};
-		2403129A1035622B709331D2 /* [CP] Copy Pods Resources */ = {
+		1255C69214146F5D3D1A8D6D /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests/Pods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests-frameworks.sh",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/OpenSSL-Universal/OpenSSL.framework/OpenSSL",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OpenSSL.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests/Pods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		2D02E4CB1E0B4B27006451C7 /* Bundle React Native Code And Images */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Bundle React Native Code And Images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/scripts/react-native-xcode.sh";
+		};
+		33769AAB94CF66BB8ED372B9 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Raygun4ReactNativeDemo/Pods-Raygun4ReactNativeDemo-frameworks.sh",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/OpenSSL-Universal/OpenSSL.framework/OpenSSL",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OpenSSL.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Raygun4ReactNativeDemo/Pods-Raygun4ReactNativeDemo-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		3B17AC717AA1F324604FBF4C /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Raygun4ReactNativeDemo-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		3B518DD0A5E066CA7C957DF6 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -377,39 +448,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests/Pods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		2B8A7FB383A4254558B065A2 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Raygun4ReactNativeDemo/Pods-Raygun4ReactNativeDemo-resources.sh",
-				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/AccessibilityResources.bundle",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AccessibilityResources.bundle",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Raygun4ReactNativeDemo/Pods-Raygun4ReactNativeDemo-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		2D02E4CB1E0B4B27006451C7 /* Bundle React Native Code And Images */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Bundle React Native Code And Images";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/scripts/react-native-xcode.sh";
-		};
-		70192FB08FF81B73EC474428 /* [CP] Check Pods Manifest.lock */ = {
+		BA27287791D9ECD58A2579F4 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -431,26 +470,22 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		7FE6F4F320153F2D06436804 /* [CP] Check Pods Manifest.lock */ = {
+		DC85596683CA2EDDD521F236 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputFileListPaths = (
-			);
 			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
+				"${PODS_ROOT}/Target Support Files/Pods-Raygun4ReactNativeDemo/Pods-Raygun4ReactNativeDemo-resources.sh",
+				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/AccessibilityResources.bundle",
 			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Raygun4ReactNativeDemo-checkManifestLockResult.txt",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AccessibilityResources.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Raygun4ReactNativeDemo/Pods-Raygun4ReactNativeDemo-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		FD10A7F022414F080027D42C /* Start Packager */ = {
@@ -498,7 +533,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				00E356F31AD99517003FC87E /* Raygun4ReactNativeDemoTests.m in Sources */,
+				00E356F31AD99517003FC87E /* Raygun4ReactNativeDemo.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -524,7 +559,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2DCD954D1E0B4F2C00145EB5 /* Raygun4ReactNativeDemoTests.m in Sources */,
+				2DCD954D1E0B4F2C00145EB5 /* Raygun4ReactNativeDemo.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -546,7 +581,7 @@
 /* Begin XCBuildConfiguration section */
 		00E356F61AD99517003FC87E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D8404A478DB92E03F795A61A /* Pods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests.debug.xcconfig */;
+			baseConfigurationReference = A2BC1A504558182E5182367E /* Pods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -569,7 +604,7 @@
 		};
 		00E356F71AD99517003FC87E /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9996511D045DD20DF4C931C3 /* Pods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests.release.xcconfig */;
+			baseConfigurationReference = BD4858C20F9AF545A07B6E7D /* Pods-Raygun4ReactNativeDemo-Raygun4ReactNativeDemoTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;
@@ -589,7 +624,7 @@
 		};
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 403E1F325A92EB8CA274AA3A /* Pods-Raygun4ReactNativeDemo.debug.xcconfig */;
+			baseConfigurationReference = 20F6A921881438629D255788 /* Pods-Raygun4ReactNativeDemo.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -612,7 +647,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7BE3D6708FB21B402ABB9889 /* Pods-Raygun4ReactNativeDemo.release.xcconfig */;
+			baseConfigurationReference = 1B244E18DADBAB27CA8609E9 /* Pods-Raygun4ReactNativeDemo.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;

--- a/sdk/ios/UIViewController+ReactNativeRaygunRUM.m
+++ b/sdk/ios/UIViewController+ReactNativeRaygunRUM.m
@@ -63,17 +63,17 @@ static NSString* iOSViewTag = @"iOS_View: ";
 
 - (void)loadViewCaptureReactNative {
     [self recordReactNativeViewLoadStartTime];
-    [self loadViewCapture];
+    [self loadViewCaptureReactNative];
 }
 
 - (void)viewDidLoadCaptureReactNative {
     [self recordReactNativeViewLoadStartTime];
-    [self viewDidLoadCapture];
+    [self viewDidLoadCaptureReactNative];
 }
 
 - (void)viewWillAppearCaptureReactNative:(BOOL)animated {
     [self recordReactNativeViewLoadStartTime];
-    [self viewWillAppearCapture:animated];
+    [self viewWillAppearCaptureReactNative:animated];
 }
 
 - (void)recordReactNativeViewLoadStartTime {
@@ -89,7 +89,7 @@ static NSString* iOSViewTag = @"iOS_View: ";
 
 - (void)viewDidAppearCaptureReactNative:(BOOL)animated {
     
-    [self viewDidAppearCapture:animated];
+    [self viewDidAppearCaptureReactNative:animated];
     
     NSNumber* timeInSeconds = [NSNumber numberWithDouble:[@(CACurrentMediaTime()) doubleValue] * 1000.0];
     

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raygun4reactnative",
   "title": "Raygun4reactnative",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Raygun React Native SDK",
   "main": "dist/index.js",
   "typescript": {


### PR DESCRIPTION
Corrected swizzling code in _ios/UIViewController+ReactNativeRaygunRUM.m_. It is still unclear why the faulty code only impacted XCTests. This patch is a band-aid on an underlying problem that should be revisited.

Methods that called themselves after swizzling occurred:
- `(void)loadViewCaptureReactNative`
- `(void)viewDidLoadCaptureReactNative`
- `(void)viewWillAppearCaptureReactNative:(BOOL)animated`
- `(void)viewDidAppearCaptureReactNative:(BOOL)animated`