### PR TITLE
[Maintainance]: Add stringify check on breadcrumb message✔️🧹 

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -14,7 +14,7 @@
     "@react-native-community/checkbox": "^0.5.7",
     "@react-navigation/bottom-tabs": "^5.11.7",
     "@react-navigation/native": "^5.9.2",
-    "raygun4reactnative": "file:raygun4reactnative-1.2.6.tgz",
+    "raygun4reactnative": "^1.0.0",
     "react": "16.13.1",
     "react-native": "0.63.0",
     "react-native-safe-area-context": "^3.1.9",

--- a/demo/package.json
+++ b/demo/package.json
@@ -14,7 +14,7 @@
     "@react-native-community/checkbox": "^0.5.7",
     "@react-navigation/bottom-tabs": "^5.11.7",
     "@react-navigation/native": "^5.9.2",
-    "raygun4reactnative": "^1.0.0",
+    "raygun4reactnative": "file:raygun4reactnative-1.2.6.tgz",
     "react": "16.13.1",
     "react-native": "0.63.0",
     "react-native-safe-area-context": "^3.1.9",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raygun4reactnative",
   "title": "Raygun4reactnative",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Raygun React Native SDK",
   "main": "dist/index.js",
   "typescript": {

--- a/sdk/src/CrashReporter.ts
+++ b/sdk/src/CrashReporter.ts
@@ -128,6 +128,13 @@ export default class CrashReporter {
   recordBreadcrumb(breadcrumb: Breadcrumb) {
     this.breadcrumbs.push({...breadcrumb});
 
+    /**
+        Android does not seem to handle the mismatched types gracefully like how iOS does.
+        Therefore we need to an additional check to avoid users app from crashing
+    **/
+
+    breadcrumb.message = JSON.stringify(breadcrumb.message);
+    
     if (this.breadcrumbs.length > this.maxBreadcrumbsPerErrorReport) {
       this.breadcrumbs.shift();
     }

--- a/sdk/src/CrashReporter.ts
+++ b/sdk/src/CrashReporter.ts
@@ -134,7 +134,7 @@ export default class CrashReporter {
     **/
 
     breadcrumb.message = JSON.stringify(breadcrumb.message);
-    
+
     if (this.breadcrumbs.length > this.maxBreadcrumbsPerErrorReport) {
       this.breadcrumbs.shift();
     }

--- a/sdk/src/CrashReporter.ts
+++ b/sdk/src/CrashReporter.ts
@@ -126,14 +126,15 @@ export default class CrashReporter {
    * @param {Breadcrumb} breadcrumb
    */
   recordBreadcrumb(breadcrumb: Breadcrumb) {
-    this.breadcrumbs.push({...breadcrumb});
 
     /**
-        Android does not seem to handle the mismatched types gracefully like how iOS does.
-        Therefore we need to an additional check to avoid users app from crashing
+       Android does not seem to handle the mismatched types gracefully like how iOS does.
+       Therefore we need to an additional check to avoid users app from crashing
     **/
 
     breadcrumb.message = JSON.stringify(breadcrumb.message);
+
+    this.breadcrumbs.push({...breadcrumb});
 
     if (this.breadcrumbs.length > this.maxBreadcrumbsPerErrorReport) {
       this.breadcrumbs.shift();


### PR DESCRIPTION
## [Maintainance]: Add stringify check on breadcrumb message ✔️🧹 

### Description 📝 
This PR is to add in a simple stringify conversion if users of this provider would like to pass through non string attributes without their app crashing.

**Updates**
👉 Add JSON.stringify to `breadcrumb.message`
👉 Bump package version

### Screenshots 📷
![AndroidTestForBreadcrumbs](https://github.com/MindscapeHQ/raygun4reactnative/assets/36393794/8d93e1bf-c729-4c10-90ae-abb53b736929)

### Test plan 🧪 
- Check is now handled gracefully on Android 

### Author to check 👓 
- [x] Builds pass
- [x] Tested in an alternative environment
- [x] Reviewed by another developer
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check ✔️ 
- [x] Change has been tested on Beta
- [x] Code is written to standards
- [x] Appropriate tests have been written (code comments, internal docs)