### PR TITLE
Minor bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ docker/
 *.plist
 &.DS_Store
 .idea
+/sdk/android/.gradle

--- a/sdk/android/build.gradle
+++ b/sdk/android/build.gradle
@@ -42,6 +42,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
 
 android {
+    namespace 'com.raygun.react'
     compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)
     buildToolsVersion safeExtGet('buildToolsVersion', DEFAULT_BUILD_TOOLS_VERSION)
     defaultConfig {

--- a/sdk/android/src/main/AndroidManifest.xml
+++ b/sdk/android/src/main/AndroidManifest.xml
@@ -1,4 +1,0 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.raygun.react">
-
-</manifest>

--- a/sdk/android/src/main/java/com/raygun/react/RaygunNativeBridgeModule.java
+++ b/sdk/android/src/main/java/com/raygun/react/RaygunNativeBridgeModule.java
@@ -136,6 +136,18 @@ public class RaygunNativeBridgeModule extends ReactContextBaseJavaModule impleme
         realUserMonitoringInitialized = true;
     }
 
+    @ReactMethod
+    public void addListener(String eventName) {
+        // Dummy method to silence NativeEventEmitter warnings in React Native.
+        // No implementation required.
+    }
+
+    @ReactMethod
+    public void removeListeners(Integer count) {
+        // Dummy method to silence NativeEventEmitter warnings in React Native.
+        // No implementation required.
+    }
+
     /**
      * This class is designed to implement CrashReportingOnBeforeSend interface from the
      * Raygun4Android SDK. Before Sending some CrashReport, this handler will ensure that the crash

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raygun4reactnative",
   "title": "Raygun4reactnative",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Raygun React Native SDK",
   "main": "dist/index.js",
   "typescript": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raygun4reactnative",
   "title": "Raygun4reactnative",
-  "version": "1.2.7",
+  "version": "1.3.0",
   "description": "Raygun React Native SDK",
   "main": "dist/index.js",
   "typescript": {

--- a/sdk/raygun4reactnative.podspec
+++ b/sdk/raygun4reactnative.podspec
@@ -21,8 +21,8 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,c,m,swift}"
   s.requires_arc = true
 
-  s.dependency "React"
   s.dependency "raygun4apple", '~> 1.5.1'
+  s.dependency "React-Core"
 
 end
 

--- a/sdk/raygun4reactnative.podspec
+++ b/sdk/raygun4reactnative.podspec
@@ -15,14 +15,14 @@ Pod::Spec.new do |s|
   # optional - use expanded license entry instead:
   # s.license    = { :type => "MIT", :file => "LICENSE" }
   s.authors      = { "MindscapeHQ" => "hello@raygun.io" }
-  s.platforms    = { :ios => "10.0" }
+  s.platforms    = { :ios => "12.0" }
   s.source       = { :git => "https://github.com/hunteva/raygun4reactnative.git", :branch => "kerwin/refactory/storage" }
 
   s.source_files = "ios/**/*.{h,c,m,swift}"
   s.requires_arc = true
 
-  s.dependency "raygun4apple", '~> 1.5.1'
   s.dependency "React-Core"
+  s.dependency "raygun4apple", '~> 2.0.0'
 
 end
 


### PR DESCRIPTION
- Address [`new NativeEventEmitter` warning](https://github.com/MindscapeHQ/raygun4reactnative/issues/75) from Android.
- [Use `React-Core` instead of `React` pod](https://github.com/facebook/react-native/issues/29633#issuecomment-694187116).
- Update Raygun4Apple sub-provider to version 2.0.0.
  - This raises the minimum iOS version to 12 (older versions _should_ still work, however).
- Move Android namespace to `build.gradle` as declaring it in `AndroidManifest.xml` is deprecated.