### PR TITLE
Dp/rg4apple dependency update

### DIFF
--- a/sdk/raygun4reactnative.podspec
+++ b/sdk/raygun4reactnative.podspec
@@ -22,6 +22,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React-Core"
-  s.dependency "raygun4apple", '~> 1.5.1'
+  s.dependency "raygun4apple", '~> 2.1.1'
 
 end

--- a/sdk/raygun4reactnative.podspec
+++ b/sdk/raygun4reactnative.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   # optional - use expanded license entry instead:
   # s.license    = { :type => "MIT", :file => "LICENSE" }
   s.authors      = { "MindscapeHQ" => "hello@raygun.io" }
-  s.platforms    = { :ios => "10.0" }
+  s.platforms    = { :ios => "12.0" }
   s.source       = { :git => "https://github.com/hunteva/raygun4reactnative.git", :branch => "kerwin/refactory/storage" }
 
   s.source_files = "ios/**/*.{h,c,m,swift}"


### PR DESCRIPTION
Updated raygun4apple dependency version to 2.1.1 and updated minimum ios version to match raygun4apple.