### PR TITLE
Add namespace to build.gradle & bump raygun4apple dependency

### DIFF
--- a/sdk/android/build.gradle
+++ b/sdk/android/build.gradle
@@ -44,6 +44,7 @@ apply plugin: 'maven-publish'
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)
     buildToolsVersion safeExtGet('buildToolsVersion', DEFAULT_BUILD_TOOLS_VERSION)
+    namespace: "com.raygun.reactnative"
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', DEFAULT_MIN_SDK_VERSION)
         targetSdkVersion safeExtGet('targetSdkVersion', DEFAULT_TARGET_SDK_VERSION)

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raygun4reactnative",
   "title": "Raygun4reactnative",
-  "version": "1.3.0",
+  "version": "1.4.3",
   "description": "Raygun React Native SDK",
   "main": "dist/index.js",
   "typescript": {

--- a/sdk/raygun4reactnative.podspec
+++ b/sdk/raygun4reactnative.podspec
@@ -22,6 +22,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React-Core"
-  s.dependency "raygun4apple", '~> 2.1.1'
+  s.dependency "raygun4apple", '~> 2.1.2'
 
 end


### PR DESCRIPTION
Adding namespace to build.gradle to prevent [this issue](https://github.com/MindscapeHQ/raygun4reactnative/issues/81). Bumped raygun4apple version to prevent a separate XCode 16 bug.