### PR TITLE
fix(android): namespace build.gradle typo

### DIFF
--- a/sdk/android/build.gradle
+++ b/sdk/android/build.gradle
@@ -44,7 +44,7 @@ apply plugin: 'maven-publish'
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)
     buildToolsVersion safeExtGet('buildToolsVersion', DEFAULT_BUILD_TOOLS_VERSION)
-    namespace: "com.raygun.reactnative"
+    namespace "com.raygun.reactnative"
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', DEFAULT_MIN_SDK_VERSION)
         targetSdkVersion safeExtGet('targetSdkVersion', DEFAULT_TARGET_SDK_VERSION)


### PR DESCRIPTION
Fixing a small typo in the namespace (just removing ":") to avoid this build issue on React Native:

```
error Failed to build the app: No package name found. We couldn't parse the namespace from neither your build.gradle[.kts] file at ******/node_modules/raygun4reactnative/android/build.gradle nor your package in the AndroidManifest at null.

[!] Invalid `Podfile` file: unexpected token at ''.

 #  from /******/ios/Podfile:35
 #  -------------------------------------------
 #    $static_framework = []
 >    config = use_native_modules!
 #    use_expo_modules!
 #  -------------------------------------------
```
 
 cc @Pallesen01 