### PR TITLE
docs: Add Sourcemap generation documentation reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
         - [RealUserMonitoringTimings](#realusermonitoringtimings)
         - [User](#user)
     - [Native Crash Reporting](#native-crash-reporting)
+    - [Generating Sourcemaps](#generating-sourcemaps)
 
 ---
 
@@ -824,5 +825,18 @@ This ensures that the platform providers are initialized before the React Native
 
 Setting `disableNativeCrashReporting` to `false` also disables all communication between Raygun4ReactNative and the platform providers,
 therefore data like breadcrumbs or user information won't be accesible by the platform providers.
+
+## Generating Sourcemaps
+
+Source Maps help to convert minified JavaScript code back into source code. R
+aygun uses them to take un-readable errors generated from minified JavaScript 
+and translate them to be readable and to include code snippets from your source.
+
+To generate them in your app, refer to the React Native documentation:
+[Enabling sourcemaps for debuging release builds](https://reactnative.dev/docs/debugging-release-builds).
+
+Once your sourcemaps have been generated,
+follow the instructions in the [JavaScript Source Maps documentation](https://raygun.com/documentation/language-guides/javascript/crash-reporting/source-maps/)
+to upload them.
 
 ---

--- a/README.md
+++ b/README.md
@@ -828,8 +828,8 @@ therefore data like breadcrumbs or user information won't be accesible by the pl
 
 ## Generating Sourcemaps
 
-Source Maps help to convert minified JavaScript code back into source code. R
-aygun uses them to take un-readable errors generated from minified JavaScript 
+Source Maps help to convert minified JavaScript code back into source code. 
+Raygun uses them to take un-readable errors generated from minified JavaScript 
 and translate them to be readable and to include code snippets from your source.
 
 To generate them in your app, refer to the React Native documentation:

--- a/README.md
+++ b/README.md
@@ -828,15 +828,11 @@ therefore data like breadcrumbs or user information won't be accesible by the pl
 
 ## Generating Sourcemaps
 
-Source Maps help to convert minified JavaScript code back into source code. 
-Raygun uses them to take un-readable errors generated from minified JavaScript 
-and translate them to be readable and to include code snippets from your source.
+Source Maps helps convert minified JavaScript code back into source code.  Raygun uses them to take unreadable errors generated from minified JavaScript, translate them to be readable, and include code snippets from your source.
 
 To generate them in your app, refer to the React Native documentation:
-[Enabling sourcemaps for debuging release builds](https://reactnative.dev/docs/debugging-release-builds).
+[Enabling sourcemaps for debugging release builds](https://reactnative.dev/docs/debugging-release-builds).
 
-Once your sourcemaps have been generated,
-follow the instructions in the [JavaScript Source Maps documentation](https://raygun.com/documentation/language-guides/javascript/crash-reporting/source-maps/)
-to upload them.
+Once your sourcemaps have been generated, follow the instructions in the [JavaScript Source Maps documentation](https://raygun.com/documentation/language-guides/javascript/crash-reporting/source-maps/) to upload them.
 
 ---


### PR DESCRIPTION
## docs: Add Sourcemap generation documentation reference

### Description :memo:

- **Purpose**: Adds documentation reference to how to generate sourcemaps and upload them to raygun
- **Approach**: Update README.md

**Type of change**

- [x] docs

**Updates**

- Update README

### Test plan :test_tube:

The sourcemap functionality has been tested to work.

This PR does not include any code changes.

### Author to check :eyeglasses:

- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:

- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)
