### PR TITLE
feat: RaygunErrorBoundary component for React error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,39 @@
+## 1.7.0
+
+This release adds a new `RaygunErrorBoundary` React component for capturing render-time errors with the React `componentStack`, upgrades the underlying native SDKs (`raygun4android` 5.2.1, `raygun4apple` 2.1.6), modernises the Android build for Gradle 9 / AGP 8.x (`compileSdkVersion 36`), and refreshes the demo projects to React Native 0.84.
+
+- feat: Add `RaygunErrorBoundary` component for capturing React render-time errors with `componentStack` (#228)
+- feat: bump raygun4apple to 2.1.6 (#226) (2026-03-12)
+- feat: bump to raygun4android v5.2.1 (#224) (2026-03-03)
+- fix: breaking changes in raygun4android 5.2.1 (#225) (2026-03-03)
+- fix: use compileSdkVersion 36 (#223) (2026-03-03)
+- fix: unhandled exception tag and fatal tag overwrite in CrashReporter (#217) (2026-02-10)
+- chore: upgrade demo projects and align dependencies (#227) (2026-03-19)
+- chore(deps): bump react-native from 0.83.1 to 0.84.1 in /demo (#220) (2026-03-02)
+- chore(deps): bump react-native from 0.80.1 to 0.83.1 in /demo (#209) (2026-01-06)
+- chore(deps): bump @react-navigation/native from 7.1.31 to 7.2.2 in /demo (#232) (2026-04-01)
+- chore(deps): bump @react-navigation/bottom-tabs in /demo (#219, #207, #203, #196, #189, #181) (2025-08 → 2026-03)
+- chore(deps): bump react-native-screens (#205, #193) (2025-11 → 2026-01)
+- chore(deps): bump react and @types/react in /demo (#201, #183, plus 2026-02-02) (2025-08 → 2026-02)
+- chore(deps-dev): bump @react-native-community/cli-platform-android (#229, #195) (2025-11, 2026-04)
+- chore(deps-dev): bump @react-native-community/cli-platform-ios in /demo (#230, #211) (2026-02, 2026-04)
+- chore(deps-dev): bump @react-native-community/cli (#188, plus 2026-02-02) (2025-10 → 2026-02)
+- chore(deps-dev): bump @react-native/babel-preset in /demo (#221, #182) (2025-08, 2026-03)
+- chore(deps-dev): bump @react-native/metro-config in /demo (#218, #202) (2025-12, 2026-03)
+- chore(deps-dev): bump @react-native/eslint-config in /demo (#222, #185) (2025-10, 2026-03)
+- chore(deps-dev): bump @react-native/typescript-config in /demo (#204) (2025-12-10)
+- chore(deps-dev): bump eslint from 8.57.1 to 9.39.2 in /demo (#208) (2026-01-02)
+- chore(deps-dev): bump typescript (#180, plus 2026-02-02) (2025-08 → 2026-02)
+- chore(deps-dev): bump prettier (#184, #206, plus 2026-02-02) (2025-08 → 2026-02)
+- chore(deps-dev): bump @babel/core from 7.28.5 to 7.29.0 in /demo (#233) (2026-04-01)
+- chore(deps-dev): bump @babel/preset-env from 7.28.0 to 7.28.5 in /demo (#194) (2025-11-01)
+- chore(deps-dev): bump @babel/runtime from 7.27.6 to 7.28.4 in /demo (#187) (2025-10-01)
+- chore(deps): bump on-headers and compression in /demo and /ExpoDemo (#178, #179) (2025-07-22)
+- chore(deps): bump gradle/actions from 4 to 6 (#199, #234) (2025-11, 2026-04)
+- chore(deps): bump actions/checkout from 4 to 6 (#191, #200) (2025-10, 2025-12)
+- chore(deps): bump actions/setup-node from 4 to 6 (#190, #198) (2025-10, 2025-11)
+- chore(deps): bump actions/setup-java from 4 to 5 (#192) (2025-10-01)
+
 ## 1.6.0
 
 This release fixes compatibility issues with the recent React-Native versions 0.79+, and it is backwards compatible with older versions as well.

--- a/ExpoDemo/app/index.tsx
+++ b/ExpoDemo/app/index.tsx
@@ -1,27 +1,63 @@
+import { useState } from "react";
 import { Button, Text, View } from "react-native";
-import RaygunClient, { LogLevel, RaygunClientOptions } from "raygun4reactnative";
+import RaygunClient, {
+  LogLevel,
+  RaygunClientOptions,
+  RaygunErrorBoundary,
+} from "raygun4reactnative";
+
+const options: RaygunClientOptions = {
+  apiKey: "INSERT_YOUR_API_KEY_HERE",
+  version: "0.1.2",
+  enableCrashReporting: true,
+  logLevel: LogLevel.verbose,
+};
+
+RaygunClient.init(options);
+
+function Crasher() {
+  const [shouldCrash, setShouldCrash] = useState(false);
+
+  if (shouldCrash) {
+    throw new Error("Render-time error from Expo demo");
+  }
+
+  return (
+    <Button
+      title="Trigger render error"
+      onPress={() => setShouldCrash(true)}
+    />
+  );
+}
 
 export default function Index() {
-
-  const options: RaygunClientOptions = {
-    apiKey: "INSERT_YOUR_API_KEY_HERE",
-    version: "0.1.2",
-    enableCrashReporting: true,
-    logLevel: LogLevel.verbose,
-  };
-  
-  RaygunClient.init(options);
-
   return (
     <View
       style={{
         flex: 1,
         justifyContent: "center",
         alignItems: "center",
+        gap: 16,
       }}
     >
       <Text>Raygun Demo</Text>
-      <Button title="Send Error" onPress={() => RaygunClient.sendError(Error("Error from Expo app"))} />
+      <Button
+        title="Send Error"
+        onPress={() => RaygunClient.sendError(Error("Error from Expo app"))}
+      />
+
+      <RaygunErrorBoundary
+        tags={["demo:expo"]}
+        fallback={({ error, reset }) => (
+          <View style={{ alignItems: "center", gap: 8 }}>
+            <Text>Caught by RaygunErrorBoundary:</Text>
+            <Text>{error.message}</Text>
+            <Button title="Reset" onPress={reset} />
+          </View>
+        )}
+      >
+        <Crasher />
+      </RaygunErrorBoundary>
     </View>
   );
 }

--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -4,6 +4,7 @@ import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
 import Home from "./screens/Home";
 import CrashReporting from "./screens/CrashReporting";
 import RealUserMonitoring from "./screens/RealUserMonitoring";
+import ErrorBoundaryScreen from "./screens/ErrorBoundary";
 import {raygunClient} from "./utils/Utils";
 import {LogLevel, RaygunClientOptions} from "raygun4reactnative";
 
@@ -46,6 +47,13 @@ function Tabs() {
         component={RealUserMonitoring}
         options={{
           tabBarLabel: 'RUM'
+        }}
+      />
+      <Tab.Screen
+        name="ErrorBoundary"
+        component={ErrorBoundaryScreen}
+        options={{
+          tabBarLabel: 'Boundary'
         }}
       />
     </Tab.Navigator>

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -12,7 +12,7 @@
         "@react-native-community/checkbox": "^0.5.20",
         "@react-navigation/bottom-tabs": "^7.15.2",
         "@react-navigation/native": "^7.2.2",
-        "raygun4reactnative": "file:raygun4reactnative-1.6.0.tgz",
+        "raygun4reactnative": "file:raygun4reactnative-1.7.0.tgz",
         "react": "19.2.3",
         "react-native": "^0.84.1",
         "react-native-safe-area-context": "^5.4.1",
@@ -9290,9 +9290,9 @@
       }
     },
     "node_modules/raygun4reactnative": {
-      "version": "1.6.0",
-      "resolved": "file:raygun4reactnative-1.6.0.tgz",
-      "integrity": "sha512-0kp2Ti0IEO9jYNL9Td+7llUR6oj3rP3Pkmvt7ewoIWZdoS5F6gIhCGxM7mhgRpdsHzpHw8e5lm9zV/yK8ns5ug==",
+      "version": "1.7.0",
+      "resolved": "file:raygun4reactnative-1.7.0.tgz",
+      "integrity": "sha512-7zup0wyVsTNuQ3gyXjCIghmkJT78NLmdGntbHaB4G87naIlDEpgMRVE0SVkorQl6NKWenUzXM1xauO+BNeRXcA==",
       "license": "MIT",
       "dependencies": {
         "@react-native-async-storage/async-storage": "^2.2.0",

--- a/demo/package.json
+++ b/demo/package.json
@@ -13,7 +13,7 @@
     "@react-native-community/checkbox": "^0.5.20",
     "@react-navigation/bottom-tabs": "^7.15.2",
     "@react-navigation/native": "^7.2.2",
-    "raygun4reactnative": "file:raygun4reactnative-1.6.0.tgz",
+    "raygun4reactnative": "file:raygun4reactnative-1.7.0.tgz",
     "react": "19.2.3",
     "react-native": "^0.84.1",
     "react-native-safe-area-context": "^5.4.1",

--- a/demo/screens/ErrorBoundary.tsx
+++ b/demo/screens/ErrorBoundary.tsx
@@ -1,0 +1,59 @@
+import React, {useState} from "react";
+import {Button, SafeAreaView, ScrollView, Text, View} from "react-native";
+import {RaygunErrorBoundary} from "raygun4reactnative";
+import {styles} from "../utils/Utils";
+
+function Crasher() {
+  const [shouldCrash, setShouldCrash] = useState(false);
+
+  if (shouldCrash) {
+    throw new Error("Test Error: render-time error from ErrorBoundary demo");
+  }
+
+  return (
+    <Button
+      title={"Trigger render error"}
+      color={"red"}
+      onPress={() => setShouldCrash(true)}
+    />
+  );
+}
+
+export default function ErrorBoundaryScreen() {
+  return (
+    <SafeAreaView>
+      <ScrollView style={styles.scrollView}>
+        <View style={styles.mainView}>
+          <View style={styles.secondView}>
+            <Text style={styles.title}>RaygunErrorBoundary</Text>
+            <Text style={styles.subtitle}>
+              Render-time errors thrown inside the boundary are reported to
+              Raygun (with React `componentStack` as custom data) and the
+              fallback UI is shown until reset.
+            </Text>
+          </View>
+
+          <View style={styles.secondView}>
+            <RaygunErrorBoundary
+              tags={["demo:error-boundary"]}
+              customData={{screen: "ErrorBoundary"}}
+              onError={(error) => {
+                console.log("[ErrorBoundary] caught:", error.message);
+              }}
+              fallback={({error, reset}) => (
+                <View style={{alignItems: "center"}}>
+                  <Text style={styles.subtitle}>
+                    Caught: {error.message}
+                  </Text>
+                  <Button title={"Reset"} color={"green"} onPress={reset} />
+                </View>
+              )}
+            >
+              <Crasher />
+            </RaygunErrorBoundary>
+          </View>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -25,6 +25,8 @@
         - [sendError](#senderrorerror-error-details-manualcrashreportdetails)
         - [setMaxReportsStoredOnDevice](#setmaxreportsstoredondevicesize-number)
         - [sendRUMTimingEvent](#sendrumtimingeventeventtype-realusermonitoringtimings-name-string-timeusedinms-number)
+    - [Components](#components)
+        - [RaygunErrorBoundary](#raygunerrorboundary)
     - [Raygun specific types](#raygun-specific-types)
         - [BeforeSendHandler](#beforesendhandler)
         - [GroupingKeyHandler](#groupingkeyhandler)
@@ -468,6 +470,8 @@ can utilize this method, and send the error through to Raygun. Appended to this 
 ManualCrashReportDetails object. This non-mandatory object can apply specific tags and CustomData to
 the error you are sending away as well as the global tags and CustomData.
 
+For React render-time errors, see [RaygunErrorBoundary](#raygunerrorboundary).
+
 See also:<br/>
 [CustomData](#customdata)
 <br/>
@@ -581,6 +585,59 @@ RaygunClient.sendRUMTimingEvent(RealUserMonitoringTimings.ViewLoaded, 'name of t
 // Monitoring a network call
 RaygunClient.sendRUMTimingEvent(RealUserMonitoringTimings.NetworkCall, 'name of the network event', 255);
 ```
+
+<br/>
+
+## Components
+
+### RaygunErrorBoundary
+
+`RaygunErrorBoundary` is a React [error boundary](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary) component that catches render-time errors anywhere in its child tree, reports them to Raygun (with the React `componentStack` attached as custom data), and renders a fallback UI in place of the crashed subtree.
+
+Use this for render-time errors. For errors caught manually in event handlers or async code, continue to use [sendError](#senderrorerror-error-details-manualcrashreportdetails).
+
+The boundary does **not** catch errors thrown by the `fallback` itself, errors in event handlers, or errors thrown asynchronously. For those, use `try/catch` with `RaygunClient.sendError`, and nest another `RaygunErrorBoundary` above if your `fallback` can throw.
+
+#### Props
+
+| Prop          | Type                                                                                                                                                                  | Description                                                                                                                                                                          |
+| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `children`    | `ReactNode`                                                                                                                                                           | The subtree to protect.                                                                                                                                                              |
+| `fallback?`   | `ReactNode \| ({ error, componentStack, reset }) => ReactNode`                                                                                                         | UI to render after an error. As a function, receives the captured error, the React `componentStack`, and a `reset` callback that clears the error and remounts `children`. If omitted, the boundary renders `null` after an error (report-only mode). On the very first fallback render, `componentStack` may be an empty string before being populated on the immediately-following re-render. The function must not throw. |
+| `tags?`       | `string[]`                                                                                                                                                            | Tags to attach to the report. Always merged (de-duplicated) with `'error-boundary'`.                                                                                                 |
+| `customData?` | `CustomData`                                                                                                                                                          | Custom data to attach to the report. The captured `componentStack` is always merged in under the `componentStack` key and overrides any user-supplied value with the same key.       |
+| `onError?`    | `(error: Error, info: ErrorInfo) => void`                                                                                                                             | Called after the error is captured.                                                                                                                                                  |
+| `onReset?`    | `(error: Error \| null, info: ErrorInfo \| null) => void`                                                                                                              | Called when `reset` is invoked from the fallback.                                                                                                                                    |
+
+#### Basic example
+
+```tsx
+import { RaygunErrorBoundary } from 'raygun4reactnative';
+
+<RaygunErrorBoundary fallback={<MyErrorScreen />}>
+  <App />
+</RaygunErrorBoundary>
+```
+
+#### Render-prop fallback with reset
+
+```tsx
+import { RaygunErrorBoundary } from 'raygun4reactnative';
+
+<RaygunErrorBoundary
+  tags={['feature:checkout']}
+  fallback={({ error, reset }) => (
+    <View>
+      <Text>Something went wrong: {error.message}</Text>
+      <Button title="Try again" onPress={reset} />
+    </View>
+  )}
+>
+  <CheckoutScreen />
+</RaygunErrorBoundary>
+```
+
+See also: [CustomData](#customdata), [sendError](#senderrorerror-error-details-manualcrashreportdetails).
 
 ---
 

--- a/sdk/__tests__/RaygunErrorBoundary.test.tsx
+++ b/sdk/__tests__/RaygunErrorBoundary.test.tsx
@@ -98,6 +98,20 @@ describe('RaygunErrorBoundary', () => {
     expect(onError).toHaveBeenCalledWith(error, info);
   });
 
+  it('invokes onError with a normalised Error when a non-Error is thrown', () => {
+    const onError = jest.fn();
+    const boundary = makeBoundary({ onError });
+    const info = { componentStack: 'cs' };
+
+    boundary.componentDidCatch('plain string' as unknown as Error, info);
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    const [reportedError, reportedInfo] = onError.mock.calls[0];
+    expect(reportedError).toBeInstanceOf(Error);
+    expect(reportedError.message).toBe('plain string');
+    expect(reportedInfo).toBe(info);
+  });
+
   it('renders a ReactNode fallback when an error is set', () => {
     const boundary = makeBoundary({ fallback: 'oops' });
     boundary.state = { error: new Error('x'), info: null };

--- a/sdk/__tests__/RaygunErrorBoundary.test.tsx
+++ b/sdk/__tests__/RaygunErrorBoundary.test.tsx
@@ -1,0 +1,156 @@
+import React from 'react';
+
+const mockSendError = jest.fn(() => Promise.resolve());
+jest.mock('../src/RaygunClient', () => ({
+  sendError: (...args: unknown[]) => mockSendError(...args)
+}));
+
+import { RaygunErrorBoundary } from '../src/RaygunErrorBoundary';
+
+const makeBoundary = (props: Partial<React.ComponentProps<typeof RaygunErrorBoundary>> = {}) => {
+  const merged = { children: 'kids', ...props } as React.ComponentProps<typeof RaygunErrorBoundary>;
+  const instance = new RaygunErrorBoundary(merged);
+  // Simulate React's setState: replace state and ignore the callback.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (instance as any).setState = (partial: any) => {
+    instance.state = { ...instance.state, ...partial };
+  };
+  return instance;
+};
+
+describe('RaygunErrorBoundary', () => {
+  beforeEach(() => {
+    mockSendError.mockClear();
+    mockSendError.mockImplementation(() => Promise.resolve());
+  });
+
+  it('renders children when no error has occurred', () => {
+    const boundary = makeBoundary({ children: 'happy' });
+    expect(boundary.render()).toBe('happy');
+  });
+
+  it('captures error via getDerivedStateFromError', () => {
+    const error = new Error('boom');
+    expect(RaygunErrorBoundary.getDerivedStateFromError(error)).toEqual({ error });
+  });
+
+  it('normalises non-Error throws in getDerivedStateFromError', () => {
+    const result = RaygunErrorBoundary.getDerivedStateFromError('string-thrown');
+    expect(result.error).toBeInstanceOf(Error);
+    expect(result.error.message).toBe('string-thrown');
+  });
+
+  it('reports error with merged tags and componentStack on componentDidCatch', async () => {
+    const boundary = makeBoundary({
+      tags: ['feature:checkout'],
+      customData: { route: '/cart' }
+    });
+    const error = new Error('crash');
+    const info = { componentStack: '\n  in Foo\n  in Bar' };
+
+    boundary.componentDidCatch(error, info);
+    await Promise.resolve();
+
+    expect(mockSendError).toHaveBeenCalledTimes(1);
+    const [reportedError, details] = mockSendError.mock.calls[0];
+    expect(reportedError).toBe(error);
+    expect(details.tags).toEqual(['error-boundary', 'feature:checkout']);
+    expect(details.customData).toEqual({
+      route: '/cart',
+      componentStack: '\n  in Foo\n  in Bar'
+    });
+  });
+
+  it('de-duplicates tags', () => {
+    const boundary = makeBoundary({ tags: ['error-boundary', 'extra'] });
+    boundary.componentDidCatch(new Error('x'), { componentStack: '' });
+    expect(mockSendError.mock.calls[0][1].tags).toEqual(['error-boundary', 'extra']);
+  });
+
+  it('boundary-supplied componentStack overrides user-supplied customData.componentStack', () => {
+    const boundary = makeBoundary({ customData: { componentStack: 'user-value' } });
+    boundary.componentDidCatch(new Error('x'), { componentStack: 'real-stack' });
+    expect(mockSendError.mock.calls[0][1].customData.componentStack).toBe('real-stack');
+  });
+
+  it('coerces a null componentStack to an empty string in customData', () => {
+    const boundary = makeBoundary();
+    boundary.componentDidCatch(new Error('x'), { componentStack: null } as unknown as React.ErrorInfo);
+    expect(mockSendError.mock.calls[0][1].customData.componentStack).toBe('');
+  });
+
+  it('normalises non-Error throws before sending', () => {
+    const boundary = makeBoundary();
+    boundary.componentDidCatch('plain string' as unknown as Error, { componentStack: '' });
+    const [reportedError] = mockSendError.mock.calls[0];
+    expect(reportedError).toBeInstanceOf(Error);
+    expect(reportedError.message).toBe('plain string');
+  });
+
+  it('invokes onError with the normalised error and info', () => {
+    const onError = jest.fn();
+    const boundary = makeBoundary({ onError });
+    const error = new Error('e');
+    const info = { componentStack: 'cs' };
+
+    boundary.componentDidCatch(error, info);
+
+    expect(onError).toHaveBeenCalledWith(error, info);
+  });
+
+  it('renders a ReactNode fallback when an error is set', () => {
+    const boundary = makeBoundary({ fallback: 'oops' });
+    boundary.state = { error: new Error('x'), info: null };
+    expect(boundary.render()).toBe('oops');
+  });
+
+  it('renders a render-prop fallback with error, componentStack, and reset', () => {
+    const fallback = jest.fn(() => 'fallback-output');
+    const error = new Error('x');
+    const boundary = makeBoundary({ fallback });
+    boundary.state = { error, info: { componentStack: 'cs' } };
+
+    const output = boundary.render();
+
+    expect(output).toBe('fallback-output');
+    expect(fallback).toHaveBeenCalledWith({
+      error,
+      componentStack: 'cs',
+      reset: boundary.reset
+    });
+  });
+
+  it('renders null when fallback is omitted but an error exists', () => {
+    const boundary = makeBoundary();
+    boundary.state = { error: new Error('x'), info: null };
+    expect(boundary.render()).toBeNull();
+  });
+
+  it('reset() clears state and invokes onReset with prior error/info', () => {
+    const onReset = jest.fn();
+    const error = new Error('x');
+    const info = { componentStack: 'cs' };
+    const boundary = makeBoundary({ onReset });
+    boundary.state = { error, info };
+
+    boundary.reset();
+
+    expect(onReset).toHaveBeenCalledWith(error, info);
+    expect(boundary.state).toEqual({ error: null, info: null });
+  });
+
+  it('swallows and logs sendError rejections without throwing', async () => {
+    mockSendError.mockImplementationOnce(() => Promise.reject(new Error('network')));
+    const boundary = makeBoundary();
+
+    expect(() => boundary.componentDidCatch(new Error('x'), { componentStack: '' })).not.toThrow();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  it('uses a fresh state object per instance', () => {
+    const a = makeBoundary();
+    const b = makeBoundary();
+    expect(a.state).not.toBe(b.state);
+  });
+});

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raygun4reactnative",
   "title": "Raygun4reactnative",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Raygun React Native SDK",
   "main": "dist/index.js",
   "typescript": {

--- a/sdk/src/RaygunErrorBoundary.tsx
+++ b/sdk/src/RaygunErrorBoundary.tsx
@@ -1,0 +1,82 @@
+import React, { Component, ErrorInfo, ReactNode } from 'react';
+import { sendError } from './RaygunClient';
+import RaygunLogger from './RaygunLogger';
+import { CustomData } from './Types';
+
+export interface RaygunErrorBoundaryFallbackProps {
+  error: Error;
+  componentStack: string;
+  reset: () => void;
+}
+
+export type RaygunErrorBoundaryFallback = ReactNode | ((props: RaygunErrorBoundaryFallbackProps) => ReactNode);
+
+export interface RaygunErrorBoundaryProps {
+  children: ReactNode;
+  fallback?: RaygunErrorBoundaryFallback;
+  tags?: string[];
+  customData?: CustomData;
+  onError?: (error: Error, info: ErrorInfo) => void;
+  onReset?: (error: Error | null, info: ErrorInfo | null) => void;
+}
+
+interface RaygunErrorBoundaryState {
+  error: Error | null;
+  info: ErrorInfo | null;
+}
+
+const INITIAL_STATE: RaygunErrorBoundaryState = { error: null, info: null };
+
+export class RaygunErrorBoundary extends Component<RaygunErrorBoundaryProps, RaygunErrorBoundaryState> {
+  state: RaygunErrorBoundaryState = { ...INITIAL_STATE };
+
+  static getDerivedStateFromError(error: unknown): Pick<RaygunErrorBoundaryState, 'error'> {
+    return { error: error instanceof Error ? error : new Error(String(error)) };
+  }
+
+  componentDidCatch(error: unknown, info: ErrorInfo) {
+    const safeError = error instanceof Error ? error : new Error(String(error));
+    const { tags, customData, onError } = this.props;
+
+    // Boundary-supplied componentStack always wins over a user-supplied
+    // customData.componentStack — keep this spread order.
+    const mergedCustomData: CustomData = {
+      ...(customData ?? {}),
+      componentStack: info.componentStack ?? ''
+    };
+    const mergedTags = Array.from(new Set(['error-boundary', ...(tags ?? [])]));
+
+    sendError(safeError, {
+      customData: mergedCustomData,
+      tags: mergedTags
+    }).catch(err => RaygunLogger.w('RaygunErrorBoundary failed to send error', err));
+
+    onError?.(safeError, info);
+    this.setState({ info });
+  }
+
+  // Arrow property gives `reset` a stable identity so it can be passed to
+  // the fallback render-prop without re-creating on every render.
+  reset = () => {
+    const { error, info } = this.state;
+    this.props.onReset?.(error, info);
+    this.setState({ ...INITIAL_STATE });
+  };
+
+  render() {
+    const { error, info } = this.state;
+    if (error === null) {
+      return this.props.children;
+    }
+
+    const { fallback } = this.props;
+    if (typeof fallback === 'function') {
+      return fallback({
+        error,
+        componentStack: info?.componentStack ?? '',
+        reset: this.reset
+      });
+    }
+    return fallback ?? null;
+  }
+}

--- a/sdk/src/RaygunErrorBoundary.tsx
+++ b/sdk/src/RaygunErrorBoundary.tsx
@@ -5,18 +5,26 @@ import { CustomData } from './Types';
 
 export interface RaygunErrorBoundaryFallbackProps {
   error: Error;
+  /** React component stack, or `''` if unavailable. */
   componentStack: string;
+  /** Clears the boundary's error state and re-renders `children`. */
   reset: () => void;
 }
 
+/** Static node, or a render-prop called with {@link RaygunErrorBoundaryFallbackProps}. */
 export type RaygunErrorBoundaryFallback = ReactNode | ((props: RaygunErrorBoundaryFallbackProps) => ReactNode);
 
 export interface RaygunErrorBoundaryProps {
   children: ReactNode;
+  /** Rendered in place of `children` once an error is captured. Defaults to `null`. */
   fallback?: RaygunErrorBoundaryFallback;
+  /** Forwarded to `sendError`. `'error-boundary'` is always added; duplicates are removed. */
   tags?: string[];
+  /** Forwarded to `sendError`. The captured React `componentStack` overrides any `componentStack` key here. */
   customData?: CustomData;
+  /** Invoked after capture. Non-`Error` throws are normalized to `Error` before being passed in. */
   onError?: (error: Error, info: ErrorInfo) => void;
+  /** Invoked from `reset()` with the error and info that were active before the reset. */
   onReset?: (error: Error | null, info: ErrorInfo | null) => void;
 }
 

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -59,3 +59,10 @@ export type {
 };
 
 export { LogLevel, RealUserMonitoringTimings };
+
+export { RaygunErrorBoundary } from './RaygunErrorBoundary';
+export type {
+  RaygunErrorBoundaryProps,
+  RaygunErrorBoundaryFallback,
+  RaygunErrorBoundaryFallbackProps
+} from './RaygunErrorBoundary';


### PR DESCRIPTION
## [#228: Feature] Add `RaygunErrorBoundary` component for React error handling

### Description :memo:

- **Purpose**: Closes [#228](https://github.com/MindscapeHQ/raygun4reactnative/issues/228). The SDK provides `RaygunClient.sendError(error)` for manually reporting caught errors but ships no built-in React error boundary, so consumers have to hand-roll a class component to capture render-time failures and lose the React `componentStack` along the way (since `sendError` doesn't accept it as structured data). This PR ships a first-party error boundary that handles both concerns automatically.
- **Approach**: Adds a new `RaygunErrorBoundary` class component that implements `componentDidCatch`, reports the error via `sendError` with the React `componentStack` merged into `customData`, applies a `'error-boundary'` tag (de-duplicated against any user-supplied tags), and renders a user-supplied `fallback` (`ReactNode` or render-prop). Naming is aligned with the existing Raygun SDK vocabulary (`customData`, `tags`, `reset`, `onError`, `onReset`). Non-`Error` throws are normalised. The component is exported from the package root alongside its prop types.

**Type of change**

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

**Updates**

:point_right: New `RaygunErrorBoundary` React component (`sdk/src/RaygunErrorBoundary.tsx`) with `fallback`, `tags`, `customData`, `onError`, and `onReset` props
:point_right: Captures React `componentStack` and forwards it to Raygun as `customData.componentStack`; auto-tags reports with `'error-boundary'`
:point_right: Unit tests covering happy path, error capture, non-`Error` normalisation, tag de-duplication, both fallback shapes, reset behavior, and rejection handling (15 tests)
:point_right: README documentation under a new `## Components` section, including caveats around fallback re-throws, SSR, and React 18 StrictMode double-invocation
:point_right: Demo wiring in both `demo` (new `ErrorBoundary` tab) and `ExpoDemo` (in-place crasher with reset)
:point_right: Version bump to 1.7.0 with CHANGELOG entry covering all changes since 1.6.0

### Screenshots :camera:

N/A — API surface is a React component; behavior is observed in the Raygun dashboard (where boundary-caught errors now appear with `componentStack` custom data and an `error-boundary` tag) and in the demo apps' fallback UI.

### Test plan :test_tube:

**Automated**

1. From `sdk/`, run `npx jest`. All 18 tests across both suites should pass (4 pre-existing + 14 new for the boundary, plus 1 added to cover null `componentStack`).
2. From `sdk/`, run `npx tsc --noEmit -p .`. Should exit 0.

**Manual — `demo` project**

1. From `sdk/`, run `npm run build_pack_1` to produce a fresh tgz, then `cd ../demo && npm install`.
2. Launch the demo on iOS or Android. Tap the new **Boundary** tab.
3. Tap **Trigger render error**. The fallback should appear showing `Caught: Test Error: render-time error from ErrorBoundary demo` and a green **Reset** button.
4. Verify in your Raygun dashboard that the error arrived with:
    - The `error-boundary` and `demo:error-boundary` tags
    - `customData.componentStack` populated with a non-empty React component stack
    - `customData.screen === 'ErrorBoundary'`
5. Tap **Reset**. The crasher button should re-appear and tapping it again should produce a second report.

**Manual — `ExpoDemo` project**

1. From `ExpoDemo/`, ensure `RAYGUN_API_KEY` is configured in `app/index.tsx`, then `npx expo start`.
2. Tap **Trigger render error**. Confirm the inline fallback ("Caught by RaygunErrorBoundary…") shows the error message and a **Reset** button.
3. Confirm the report appears in Raygun with the `error-boundary` and `demo:expo` tags and the React component stack in custom data.

**Edge cases worth probing**

- Throw a non-`Error` value (`throw 'oops'`) inside the boundary and confirm it still reports (normalised to `Error('oops')`).
- Pass `'error-boundary'` explicitly in the `tags` prop and confirm only one occurrence reaches Raygun.
- Provide a `customData={{ componentStack: 'user-value' }}` and confirm the real React stack overrides it.

### Author to check :eyeglasses:

- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:

- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)