### PR TITLE
fix: exclude `kotlin-stdlib` from raygun4android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.7.1
+
+This release fixes an Android build failure for consumers whose Kotlin compiler is older than the version `raygun4android` was compiled against (notably Expo SDK 55 / React Native 0.81, which pin Kotlin 2.1.20).
+
+- fix: exclude `kotlin-stdlib` from `raygun4android` to avoid forcing a stdlib upgrade on the host app (#237)
+
 ## 1.7.0
 
 This release adds a new `RaygunErrorBoundary` React component for capturing render-time errors with the React `componentStack`, upgrades the underlying native SDKs (`raygun4android` 5.2.1, `raygun4apple` 2.1.6), modernises the Android build for Gradle 9 / AGP 8.x (`compileSdkVersion 36`), and refreshes the demo projects to React Native 0.84.

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -12,7 +12,7 @@
         "@react-native-community/checkbox": "^0.5.20",
         "@react-navigation/bottom-tabs": "^7.15.2",
         "@react-navigation/native": "^7.2.2",
-        "raygun4reactnative": "file:raygun4reactnative-1.7.0.tgz",
+        "raygun4reactnative": "file:raygun4reactnative-1.7.1.tgz",
         "react": "19.2.3",
         "react-native": "^0.84.1",
         "react-native-safe-area-context": "^5.4.1",

--- a/demo/package.json
+++ b/demo/package.json
@@ -13,7 +13,7 @@
     "@react-native-community/checkbox": "^0.5.20",
     "@react-navigation/bottom-tabs": "^7.15.2",
     "@react-navigation/native": "^7.2.2",
-    "raygun4reactnative": "file:raygun4reactnative-1.7.0.tgz",
+    "raygun4reactnative": "file:raygun4reactnative-1.7.1.tgz",
     "react": "19.2.3",
     "react-native": "^0.84.1",
     "react-native-safe-area-context": "^5.4.1",

--- a/sdk/android/build.gradle
+++ b/sdk/android/build.gradle
@@ -47,7 +47,14 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-android:+'
-    implementation 'com.raygun:raygun4android:5.2.1'
+    // Exclude kotlin-stdlib so the host app's Kotlin version wins conflict resolution.
+    // raygun4android's stdlib (currently 2.3.0) would otherwise force-upgrade stdlib for
+    // every other module in the graph, breaking builds whose Kotlin compiler is older
+    // (e.g. React Native 0.81 / Expo SDK 55 pin Kotlin 2.1.20, which cannot read 2.3.0
+    // metadata). See https://github.com/MindscapeHQ/raygun4reactnative/issues/237.
+    implementation('com.raygun:raygun4android:5.2.1') {
+        exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib'
+    }
     implementation 'com.jakewharton.timber:timber:4.7.1'
 }
 

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raygun4reactnative",
   "title": "Raygun4reactnative",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Raygun React Native SDK",
   "main": "dist/index.js",
   "typescript": {


### PR DESCRIPTION
## [#237: fix] Exclude `kotlin-stdlib` from `raygun4android` transitive dependency

### Description :memo:

- **Purpose**: Fixes Android build failures on host apps whose Kotlin compiler is older than the one `raygun4android` was compiled against. `raygun4android:5.2.1` pulls `org.jetbrains.kotlin:kotlin-stdlib:2.3.0` transitively. 
- **Approach**: Exclude `org.jetbrains.kotlin:kotlin-stdlib` from the `raygun4android` dependency declaration in `sdk/android/build.gradle`. This lets the host app's Kotlin stdlib version win conflict resolution.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**Updates**

:point_right: `sdk/android/build.gradle` — add `exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib'` to the `raygun4android` dependency, with a comment explaining why and linking to #237.
:point_right: `sdk/package.json` — bump version `1.7.0` → `1.7.1`.
:point_right: `CHANGELOG.md` — add `1.7.1` section describing the fix.
:point_right: `demo/package.json` + `demo/package-lock.json` — update local `raygun4reactnative-*.tgz` reference to `1.7.1`.

### Screenshots :camera:

N/A — Gradle dependency config change, no UI impact.

### Author to check :eyeglasses:

- [ ] Project and all contained modules builds successfully
- [ ] Self-/dev-tested
- [ ] Unit/UI/Automation/Integration tests provided where applicable — N/A, Gradle config change
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:

- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable — N/A
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)
